### PR TITLE
Fix install_local(".")

### DIFF
--- a/R/install-local.R
+++ b/R/install-local.R
@@ -23,7 +23,7 @@ install_local <- function(path, subdir = NULL, ...) {
 
 local_remote <- function(path, subdir = NULL, branch = NULL, args = character(0)) {
   remote("local",
-    path = path,
+    path = normalizePath(path),
     subdir = subdir
   )
 }


### PR DESCRIPTION
by calling `normalizePath()` when constructing the remote. Closes #67.

Do we need a test?