### PR TITLE
Initial support for git submodules

### DIFF
--- a/R/install-git.R
+++ b/R/install-git.R
@@ -142,6 +142,7 @@ read_gitmodules <- function(file) {
   modules <- gsub('\n(\\[submodule \\".*?\\"\\])', '%split%\\1', modules)
   modules <- strsplit(modules, '%split%')
   modules <- lapply(unlist(modules), parse_module)
+  modules <- modules[sapply(modules, function(x) all(c("name", "path", "url", "branch") %in% names(x)))]
   modules
 }
 
@@ -161,6 +162,12 @@ parse_module <- function(module_string) {
   branch <- gsub('.*= *(.*)',
                  '\\1',
                  module_strings[grepl('branch', module_strings)])
+
+  # if there is no url string return an empty list, which we filter out later
+  if(!any(grepl('url', module_strings))){
+    return(list())
+  }
+
   # if there is no branch string, set branch to NULL
   if(!any(grepl('branch', module_strings))){
     branch <- NULL

--- a/R/install-github.R
+++ b/R/install-github.R
@@ -13,6 +13,7 @@
 #' @param ref Desired git reference. Could be a commit, tag, or branch
 #'   name, or a call to \code{\link{github_pull}}. Defaults to \code{"master"}.
 #' @param subdir subdirectory within repo that contains the R package.
+#' @param submodules if \code{TRUE} download submodules before installing.
 #' @param auth_token To install from a private repo, generate a personal
 #'   access token (PAT) in \url{https://github.com/settings/applications} and
 #'   supply to this argument. This is safer than using a password because
@@ -47,17 +48,19 @@
 #' }
 install_github <- function(repo, username = NULL,
                            ref = "master", subdir = NULL,
+                           submodules = FALSE,
                            auth_token = github_pat(),
                            host = "api.github.com", ...) {
 
   remotes <- lapply(repo, github_remote, username = username, ref = ref,
-    subdir = subdir, auth_token = auth_token, host = host)
+    subdir = subdir, submodules = submodules, auth_token = auth_token,
+    host = host)
 
   install_remotes(remotes, ...)
 }
 
 github_remote <- function(repo, username = NULL, ref = NULL, subdir = NULL,
-                       auth_token = github_pat(), sha = NULL,
+                       submodules = FALSE, auth_token = github_pat(), sha = NULL,
                        host = "api.github.com") {
 
   meta <- parse_git_repo(repo)
@@ -74,6 +77,7 @@ github_remote <- function(repo, username = NULL, ref = NULL, subdir = NULL,
     host = host,
     repo = meta$repo,
     subdir = meta$subdir %||% subdir,
+    submodules = submodules,
     username = meta$username,
     ref = meta$ref,
     sha = sha,

--- a/R/install-github.R
+++ b/R/install-github.R
@@ -26,7 +26,8 @@
 #' raises a warning. Because the zipped sources provided by GitHub do not
 #' include submodules, this may lead to unexpected behaviour or compilation
 #' failure in source packages. In this case, cloning the repository manually
-#' may yield better results.
+#' using \code{\link{install_git}} with \code{submodules=TRUE} may yield
+#' better results.
 #' @export
 #' @seealso \code{\link{github_pull}}
 #' @examples

--- a/R/install-remote.R
+++ b/R/install-remote.R
@@ -17,6 +17,13 @@ install_remote <- function(remote, ..., quiet = FALSE) {
   source <- source_pkg(bundle, subdir = remote$subdir)
   on.exit(unlink(source, recursive = TRUE), add = TRUE)
 
+  # check if there are submodules, download them if there are.
+  if (file.exists(file.path(source, ".gitmodules")) &&
+      inherits(remote, "git_remote") && remote$submodules) {
+    submodules <- read_gitmodules(file.path(source, ".gitmodules"))
+    download_modules(submodules, source=source)
+  }
+
   add_metadata(source, remote_metadata(remote, bundle, source))
 
   # Because we've modified DESCRIPTION, its original MD5 value is wrong

--- a/R/install-remote.R
+++ b/R/install-remote.R
@@ -63,7 +63,7 @@ remote <- function(type, ...) {
 }
 is.remote <- function(x) inherits(x, "remote")
 
-is.git_remote <- function(x) inherits(x, "git2r_remote") || inherits(x, "xgit_remote")
+is.git_remote <- function(x) inherits(x, "git2r_remote") || inherits(x, "xgit_remote") || inherits(x, "github_remote")
 
 remote_download <- function(x, quiet = FALSE) UseMethod("remote_download")
 remote_metadata <- function(x, bundle = NULL, source = NULL) UseMethod("remote_metadata")

--- a/R/install-remote.R
+++ b/R/install-remote.R
@@ -19,7 +19,7 @@ install_remote <- function(remote, ..., quiet = FALSE) {
 
   # check if there are submodules, download them if there are.
   if (file.exists(file.path(source, ".gitmodules")) &&
-      inherits(remote, "git_remote") && remote$submodules) {
+      is.git_remote(remote) && remote$submodules) {
     submodules <- read_gitmodules(file.path(source, ".gitmodules"))
     download_modules(submodules, source=source)
   }
@@ -62,6 +62,8 @@ remote <- function(type, ...) {
   structure(list(...), class = c(paste0(type, "_remote"), "remote"))
 }
 is.remote <- function(x) inherits(x, "remote")
+
+is.git_remote <- function(x) inherits(x, "git2r_remote") || inherits(x, "xgit_remote")
 
 remote_download <- function(x, quiet = FALSE) UseMethod("remote_download")
 remote_metadata <- function(x, bundle = NULL, source = NULL) UseMethod("remote_metadata")

--- a/man/install_git.Rd
+++ b/man/install_git.Rd
@@ -4,8 +4,8 @@
 \alias{install_git}
 \title{Install a package from a git repository}
 \usage{
-install_git(url, subdir = NULL, branch = NULL, git = c("auto", "git2r",
-  "external"), ...)
+install_git(url, subdir = NULL, branch = NULL, submodules = FALSE,
+  git = c("auto", "git2r", "external"), ...)
 }
 \arguments{
 \item{url}{Location of package. The url should point to a public or
@@ -15,6 +15,8 @@ private repository.}
 contain the package we are interested in installing.}
 
 \item{branch}{Name of branch or tag to use, if not master.}
+
+\item{submodules}{if \code{TRUE} download submodules before installing.}
 
 \item{git}{Whether to use the \code{git2r} package, or an external
 git client via system. Default is \code{git2r} if it is installed,

--- a/man/install_github.Rd
+++ b/man/install_github.Rd
@@ -5,7 +5,8 @@
 \title{Attempts to install a package directly from GitHub.}
 \usage{
 install_github(repo, username = NULL, ref = "master", subdir = NULL,
-  auth_token = github_pat(), host = "api.github.com", ...)
+  submodules = FALSE, auth_token = github_pat(),
+  host = "api.github.com", ...)
 }
 \arguments{
 \item{repo}{Repository address in the format
@@ -21,6 +22,8 @@ precedence.}
 name, or a call to \code{\link{github_pull}}. Defaults to \code{"master"}.}
 
 \item{subdir}{subdirectory within repo that contains the R package.}
+
+\item{submodules}{if \code{TRUE} download submodules before installing.}
 
 \item{auth_token}{To install from a private repo, generate a personal
 access token (PAT) in \url{https://github.com/settings/applications} and

--- a/man/install_github.Rd
+++ b/man/install_github.Rd
@@ -42,7 +42,8 @@ Attempting to install from a source repository that uses submodules
 raises a warning. Because the zipped sources provided by GitHub do not
 include submodules, this may lead to unexpected behaviour or compilation
 failure in source packages. In this case, cloning the repository manually
-may yield better results.
+using \code{\link{install_git}} with \code{submodules=TRUE} may yield
+better results.
 }
 \examples{
 \dontrun{

--- a/tests/testthat/test-install-git.R
+++ b/tests/testthat/test-install-git.R
@@ -76,3 +76,32 @@ test_that("remote_metadata.git2r_remote", {
 
   expect_equal(r, e)
 })
+
+context("Install git submodules")
+
+goldStandard <- list(name = "testRepo",
+                     path = "testRepo",
+                     url = "http://github.com/user/testRepo",
+                     branch = NULL)
+
+gitmodule <- '[submodule "testRepo"]
+	path = testRepo
+url = http://github.com/user/testRepo'
+
+test_that("parse_module returns null branch when none is given", {
+  expect_equal(parse_module(gitmodule), goldStandard)
+})
+
+goldStandard <- list(name = "testRepo",
+                     path = "testRepo",
+                     url = "http://github.com/user/testRepo",
+                     branch = "devel")
+
+gitmodule <- '[submodule "testRepo"]
+	path = testRepo
+url = http://github.com/user/testRepo
+branch = devel'
+
+test_that("parse_module returns devel branch when devel is given", {
+  expect_equal(parse_module(gitmodule), goldStandard)
+})


### PR DESCRIPTION
This initial support is based on the work done by @jonkeane for devtools, plus minor additions from my side. It includes submodules support for git2r, xgit and github remotes. It is not fully recursive yet, and the code is still not all cleanly separated, but it works as a first approach.

This pull request addresses #82.