### PR TITLE
Use re_match() in parse_github_repo_spec()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,8 +18,9 @@ Description: Download and install R packages stored in 'GitHub',
 License: GPL (>= 2)
 URL: https://github.com/r-lib/remotes#readme
 BugReports: https://github.com/r-lib/remotes/issues
-Imports:
+Imports: 
     methods,
+    rematch2,
     utils
 Suggests:
     crancache,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ Description: Download and install R packages stored in 'GitHub',
 License: GPL (>= 2)
 URL: https://github.com/r-lib/remotes#readme
 BugReports: https://github.com/r-lib/remotes/issues
-Imports: 
+Imports:
     methods,
     rematch2,
     utils

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,6 @@ URL: https://github.com/r-lib/remotes#readme
 BugReports: https://github.com/r-lib/remotes/issues
 Imports:
     methods,
-    rematch2,
     utils
 Suggests:
     crancache,

--- a/R/install-github.R
+++ b/R/install-github.R
@@ -280,15 +280,15 @@ parse_github_repo_spec <- function(repo) {
     "(?:%s|%s|%s)?", ref_rx, pull_rx, release_rx
   )
   github_rx  <- sprintf(
-    "^(?:%s%s%s%s|(?<catchall>.*))$",
-    username_rx, repo_rx, subdir_rx, ref_or_pull_or_release_rx
+    "^%s%s%s%s$", username_rx, repo_rx, subdir_rx, ref_or_pull_or_release_rx
   )
   params <- as.list(re_match(text = repo, pattern = github_rx))
 
-  params <- params[viapply(params, nchar) > 0 & grepl("^[^\\.]", names(params))]
-  if (!is.null(params$catchall)) {
-    stop(sprintf("Invalid git repo specification: %s", repo))
+  if (is.na(params$.match)) {
+    stop(sprintf("Invalid git repo specification: '%s'", repo))
   }
+  params <- params[viapply(params, nchar) > 0 & grepl("^[^\\.]", names(params))]
+
   params
 }
 

--- a/R/install-github.R
+++ b/R/install-github.R
@@ -269,23 +269,26 @@ parse_github_repo_spec <- function(repo) {
     repo <- paste(match[2], gsub("\\.git", "", match[3]), sep = "/")
   }
 
-  username_rx <- "(?:([^/]+)/)?"
-  repo_rx <- "([^/@#]+)"
-  subdir_rx <- "(?:/([^@#]*[^@#/])/?)?"
-  ref_rx <- "(?:@([^*].*))"
-  pull_rx <- "(?:#([0-9]+))"
-  release_rx <- "(?:@([*]release))"
-  ref_or_pull_or_release_rx <- sprintf("(?:%s|%s|%s)?", ref_rx, pull_rx, release_rx)
-  github_rx <- sprintf("^(?:%s%s%s%s|(.*))$",
-                       username_rx, repo_rx, subdir_rx, ref_or_pull_or_release_rx)
+  username_rx <- "(?:(?<username>[^/]+)/)?"
+  repo_rx     <- "(?<repo>[^/@#]+)"
+  subdir_rx   <- "(?:/(?<subdir>[^@#]*[^@#/])/?)?"
+  ref_rx      <- "(?:@(?<ref>[^*].*))"
+  pull_rx     <- "(?:#(?<pull>[0-9]+))"
+  release_rx  <- "(?:@(?<release>[*]release))"
 
-  param_names <- c("username", "repo", "subdir", "ref", "pull", "release", "invalid")
-  replace <- stats::setNames(sprintf("\\%d", seq_along(param_names)), param_names)
-  params <- lapply(replace, function(r) gsub(github_rx, r, repo, perl = TRUE))
-  if (params$invalid != "")
-    stop(sprintf("Invalid git repo: %s", repo))
-  params <- params[viapply(params, nchar) > 0]
+  ref_or_pull_or_release_rx <- sprintf(
+    "(?:%s|%s|%s)?", ref_rx, pull_rx, release_rx
+  )
+  github_rx  <- sprintf(
+    "^(?:%s%s%s%s|(?<catchall>.*))$",
+    username_rx, repo_rx, subdir_rx, ref_or_pull_or_release_rx
+  )
+  params <- as.list(rematch2::re_match(text = repo, pattern = github_rx))
 
+  params <- params[viapply(params, nchar) > 0 & grepl("^[^\\.]", names(params))]
+  if (!is.null(params$catchall)) {
+    stop(sprintf("Invalid git repo specification: %s", repo))
+  }
   params
 }
 

--- a/R/install-github.R
+++ b/R/install-github.R
@@ -283,7 +283,7 @@ parse_github_repo_spec <- function(repo) {
     "^(?:%s%s%s%s|(?<catchall>.*))$",
     username_rx, repo_rx, subdir_rx, ref_or_pull_or_release_rx
   )
-  params <- as.list(rematch2::re_match(text = repo, pattern = github_rx))
+  params <- as.list(re_match(text = repo, pattern = github_rx))
 
   params <- params[viapply(params, nchar) > 0 & grepl("^[^\\.]", names(params))]
   if (!is.null(params$catchall)) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -127,3 +127,42 @@ untar_description <- function(tarball, dir = tempfile()) {
   untar(tarball, desc, exdir = dir)
   file.path(dir, desc)
 }
+
+## copied from rematch2@180fb61
+re_match <- function(text, pattern, perl = TRUE, ...) {
+
+  stopifnot(is.character(pattern), length(pattern) == 1, !is.na(pattern))
+  text <- as.character(text)
+
+  match <- regexpr(pattern, text, perl = perl, ...)
+
+  start  <- as.vector(match)
+  length <- attr(match, "match.length")
+  end    <- start + length - 1L
+
+  matchstr <- substring(text, start, end)
+  matchstr[ start == -1 ] <- NA_character_
+
+  res <- data.frame(
+    stringsAsFactors = FALSE,
+    .text = text,
+    .match = matchstr
+  )
+
+  if (!is.null(attr(match, "capture.start"))) {
+
+    gstart  <- attr(match, "capture.start")
+    glength <- attr(match, "capture.length")
+    gend    <- gstart + glength - 1L
+
+    groupstr <- substring(text, gstart, gend)
+    groupstr[ gstart == -1 ] <- NA_character_
+    dim(groupstr) <- dim(gstart)
+
+    res <- cbind(groupstr, res, stringsAsFactors = FALSE)
+  }
+
+  names(res) <- c(attr(match, "capture.names"), ".text", ".match")
+  class(res) <- c("tbl_df", "tbl", class(res))
+  res
+}

--- a/tests/testthat/test-install-github.R
+++ b/tests/testthat/test-install-github.R
@@ -369,3 +369,10 @@ test_that("parse_github_repo_spec insists that browser URLs ends with repo", {
     "must end with repo name"
   )
 })
+
+test_that("parse_github_repo_spec catches invalid spec", {
+  expect_error(
+    parse_github_repo_spec("/$&@R64&3"),
+    "Invalid git repo specification"
+  )
+})


### PR DESCRIPTION
I plan to make a PR for handling the other forms of GitHub URL, such as for a commit, branch, release or pull. But it might be nice to have access to rematch2. And, in that case, maybe we could enjoy it here first?