### PR TITLE
add links to install.packages in the documentation

### DIFF
--- a/R/deps.R
+++ b/R/deps.R
@@ -333,7 +333,7 @@ standardise_dep <- function(x) {
 
 #' Update packages that are missing or out-of-date.
 #'
-#' Works similarly to \code{install.packages()} but doesn't install packages
+#' Works similarly to \code{\link[utils]{install.packages}} but doesn't install packages
 #' that are already installed, and also upgrades out dated dependencies.
 #'
 #' @param packages Character vector of packages to update.

--- a/R/install-git.R
+++ b/R/install-git.R
@@ -13,7 +13,7 @@
 #' @param git Whether to use the \code{git2r} package, or an external
 #'   git client via system. Default is \code{git2r} if it is installed,
 #'   otherwise an external git installation.
-#' @param ... passed on to \code{install.packages}
+#' @param ... passed on to \code{\link[utils]{install.packages}}
 #' @export
 #' @examples
 #' \dontrun{

--- a/R/install-github.R
+++ b/R/install-github.R
@@ -20,7 +20,7 @@
 #'   the \code{GITHUB_PAT} environment variable.
 #' @param host GitHub API host to use. Override with your GitHub enterprise
 #'   hostname, for example, \code{"github.hostname.com/api/v3"}.
-#' @param ... Other arguments passed on to \code{install.packages}.
+#' @param ... Other arguments passed on to \code{\link[utils]{install.packages}}.
 #' @details
 #' Attempting to install from a source repository that uses submodules
 #' raises a warning. Because the zipped sources provided by GitHub do not

--- a/R/install-svn.R
+++ b/R/install-svn.R
@@ -9,11 +9,11 @@
 #'
 #' @inheritParams install_git
 #' @param subdir A sub-directory withing a svn repository that contains the
-#'   package we are interested in installing. 
+#'   package we are interested in installing.
 #' @param args A character vector providing extra options to pass on to
 #'   \command{svn}.
 #' @param revision svn revision, if omitted updates to latest
-#' @param ... Other arguments passed on to \code{install.packages}.
+#' @param ... Other arguments passed on to \code{\link[utils]{install.packages}}.
 #' @export
 #'
 #' @examples
@@ -54,7 +54,7 @@ remote_download.svn_remote <- function(x, quiet = FALSE) {
     args <- paste("-r", x$revision, args)
   if (!is.null(x$svn_subdir)) {
     url <- file.path(url, x$svn_subdir);
-  } 
+  }
   args <- c(x$args, args, url, bundle)
 
   message(shQuote(svn_binary_path), " ", paste0(args, collapse = " "))

--- a/R/install-url.R
+++ b/R/install-url.R
@@ -7,7 +7,7 @@
 #' @param url location of package on internet. The url should point to a
 #'   zip file, a tar file or a bzipped/gzipped tar file.
 #' @param subdir subdirectory within url bundle that contains the R package.
-#' @param ... Other arguments passed on to \code{install.packages}.
+#' @param ... Other arguments passed on to \code{\link[utils]{install.packages}}.
 #' @export
 #'
 #' @examples

--- a/R/install-version.R
+++ b/R/install-version.R
@@ -11,9 +11,9 @@
 #' @param package package name
 #' @param version If the specified version is NULL or the same as the most
 #'   recent version of the package, this function simply calls
-#'   \code{install.packages}. Otherwise, it looks at the list of
+#'   \code{\link[utils]{install.packages}}. Otherwise, it looks at the list of
 #'   archived source tarballs and tries to install an older version instead.
-#' @param ... Other arguments passed on to \code{install.packages}.
+#' @param ... Other arguments passed on to \code{\link[utils]{install.packages}}.
 #' @inheritParams utils::install.packages
 #' @author Jeremy Stephens
 #' @importFrom utils available.packages contrib.url install.packages

--- a/R/install.R
+++ b/R/install.R
@@ -48,8 +48,8 @@ safe_install_packages <- function(...) {
 #'
 #' @inheritParams package_deps
 #' @param threads Number of threads to start, passed to
-#'   \code{install.packages} as \code{Ncpus}.
-#' @param ... additional arguments passed to \code{\link{install.packages}}.
+#'   \code{\link[utils]{install.packages}} as \code{Ncpus}.
+#' @param ... additional arguments passed to \code{\link[utils]{install.packages}}.
 #' @export
 #' @examples
 #' \dontrun{install_deps(".")}

--- a/install-github.R
+++ b/install-github.R
@@ -3,7 +3,7 @@ function(...) {
 
   ## This is the code of the package, put in here by brew
 
-  
+
 bioc_version <- function() {
   bver <- get(
     ".BioC_version_associated_with_R_version",
@@ -64,7 +64,7 @@ bioc_install_repos <- function() {
     }
   }
   if (vers >= "3.4") {
-    a[, "URL"] <- sub(as.character(biocVers), "3.4", a[, "URL"]) 
+    a[, "URL"] <- sub(as.character(biocVers), "3.4", a[, "URL"])
 
   } else if (vers >= "3.3.0") {
     a[, "URL"] <- sub(as.character(biocVers), "3.4", a[, "URL"])
@@ -562,7 +562,7 @@ standardise_dep <- function(x) {
 
 #' Update packages that are missing or out-of-date.
 #'
-#' Works similarly to \code{install.packages()} but doesn't install packages
+#' Works similarly to \code{\link[utils]{install.packages}} but doesn't install packages
 #' that are already installed, and also upgrades out dated dependencies.
 #'
 #' @param packages Character vector of packages to update.
@@ -708,20 +708,20 @@ base_download <- function(url, path, quiet) {
 }
 
 download_method <- function() {
-  
+
   # R versions newer than 3.3.0 have correct default methods
   if (compareVersion(get_r_version(), "3.3") == -1) {
-    
+
     if (os_type() == "windows") {
       "wininet"
-      
+
     } else if (isTRUE(unname(capabilities("libcurl")))) {
       "libcurl"
-      
+
     } else {
       "auto"
     }
-    
+
   } else {
     "auto"
   }
@@ -957,7 +957,7 @@ remote_metadata.bitbucket_remote <- function(x, bundle = NULL, source = NULL) {
 #' @param git Whether to use the \code{git2r} package, or an external
 #'   git client via system. Default is \code{git2r} if it is installed,
 #'   otherwise an external git installation.
-#' @param ... passed on to \code{install.packages}
+#' @param ... passed on to \code{\link[utils]{install.packages}}
 #' @export
 #' @examples
 #' \dontrun{
@@ -1096,7 +1096,7 @@ xgit_remote_sha1 <- function(url, ref = "master") {
 #'   the \code{GITHUB_PAT} environment variable.
 #' @param host GitHub API host to use. Override with your GitHub enterprise
 #'   hostname, for example, \code{"github.hostname.com/api/v3"}.
-#' @param ... Other arguments passed on to \code{install.packages}.
+#' @param ... Other arguments passed on to \code{\link[utils]{install.packages}}.
 #' @details
 #' Attempting to install from a source repository that uses submodules
 #' raises a warning. Because the zipped sources provided by GitHub do not
@@ -1472,11 +1472,11 @@ remote_metadata <- function(x, bundle = NULL, source = NULL) UseMethod("remote_m
 #'
 #' @inheritParams install_git
 #' @param subdir A sub-directory withing a svn repository that contains the
-#'   package we are interested in installing. 
+#'   package we are interested in installing.
 #' @param args A character vector providing extra options to pass on to
 #'   \command{svn}.
 #' @param revision svn revision, if omitted updates to latest
-#' @param ... Other arguments passed on to \code{install.packages}.
+#' @param ... Other arguments passed on to \code{\link[utils]{install.packages}}.
 #' @export
 #'
 #' @examples
@@ -1517,7 +1517,7 @@ remote_download.svn_remote <- function(x, quiet = FALSE) {
     args <- paste("-r", x$revision, args)
   if (!is.null(x$svn_subdir)) {
     url <- file.path(url, x$svn_subdir);
-  } 
+  }
   args <- c(x$args, args, url, bundle)
 
   message(shQuote(svn_binary_path), " ", paste0(args, collapse = " "))
@@ -1575,7 +1575,7 @@ svn_path <- function(svn_binary_name = NULL) {
 #' @param url location of package on internet. The url should point to a
 #'   zip file, a tar file or a bzipped/gzipped tar file.
 #' @param subdir subdirectory within url bundle that contains the R package.
-#' @param ... Other arguments passed on to \code{install.packages}.
+#' @param ... Other arguments passed on to \code{\link[utils]{install.packages}}.
 #' @export
 #'
 #' @examples
@@ -1629,9 +1629,9 @@ remote_metadata.url_remote <- function(x, bundle = NULL, source = NULL) {
 #' @param package package name
 #' @param version If the specified version is NULL or the same as the most
 #'   recent version of the package, this function simply calls
-#'   \code{install.packages}. Otherwise, it looks at the list of
+#'   \code{\link[utils]{install.packages}}. Otherwise, it looks at the list of
 #'   archived source tarballs and tries to install an older version instead.
-#' @param ... Other arguments passed on to \code{install.packages}.
+#' @param ... Other arguments passed on to \code{\link[utils]{install.packages}}.
 #' @inheritParams utils::install.packages
 #' @author Jeremy Stephens
 #' @importFrom utils available.packages contrib.url install.packages
@@ -1771,8 +1771,8 @@ safe_install_packages <- function(...) {
 #'
 #' @inheritParams package_deps
 #' @param threads Number of threads to start, passed to
-#'   \code{install.packages} as \code{Ncpus}.
-#' @param ... additional arguments passed to \code{\link{install.packages}}.
+#'   \code{\link[utils]{install.packages}} as \code{Ncpus}.
+#' @param ... additional arguments passed to \code{\link[utils]{install.packages}}.
 #' @export
 #' @examples
 #' \dontrun{install_deps(".")}

--- a/man/download_version.Rd
+++ b/man/download_version.Rd
@@ -12,7 +12,7 @@ download_version(package, version = NULL, repos = getOption("repos"),
 
 \item{version}{If the specified version is NULL or the same as the most
 recent version of the package, this function simply calls
-\code{install.packages}. Otherwise, it looks at the list of
+\code{\link[utils]{install.packages}}. Otherwise, it looks at the list of
 archived source tarballs and tries to install an older version instead.}
 
 \item{repos}{
@@ -30,7 +30,7 @@ archived source tarballs and tries to install an older version instead.}
     builds: see the section on \sQuote{Binary packages} for those.
   }
 
-\item{...}{Other arguments passed on to \code{install.packages}.}
+\item{...}{Other arguments passed on to \code{\link[utils]{install.packages}}.}
 }
 \value{
 Name of the downloaded file.

--- a/man/install_bitbucket.Rd
+++ b/man/install_bitbucket.Rd
@@ -25,7 +25,7 @@ to \code{username})}
 
 \item{password}{your password}
 
-\item{...}{Other arguments passed on to \code{install.packages}.}
+\item{...}{Other arguments passed on to \code{\link[utils]{install.packages}}.}
 }
 \description{
 This function is vectorised so you can install multiple packages in

--- a/man/install_deps.Rd
+++ b/man/install_deps.Rd
@@ -21,7 +21,7 @@ install_deps(pkgdir = ".", dependencies = NA, threads = getOption("Ncpus",
   just check this package, not its dependencies).}
 
 \item{threads}{Number of threads to start, passed to
-\code{install.packages} as \code{Ncpus}.}
+\code{\link[utils]{install.packages}} as \code{Ncpus}.}
 
 \item{repos}{A character vector giving repositories to use.}
 
@@ -29,7 +29,7 @@ install_deps(pkgdir = ".", dependencies = NA, threads = getOption("Ncpus",
 automatically to "binary" to avoid interactive prompts during package
 installation.}
 
-\item{...}{additional arguments passed to \code{\link{install.packages}}.}
+\item{...}{additional arguments passed to \code{\link[utils]{install.packages}}.}
 
 \item{upgrade}{If \code{TRUE}, also upgrade any of out date dependencies.}
 

--- a/man/install_git.Rd
+++ b/man/install_git.Rd
@@ -20,7 +20,7 @@ contain the package we are interested in installing.}
 git client via system. Default is \code{git2r} if it is installed,
 otherwise an external git installation.}
 
-\item{...}{passed on to \code{install.packages}}
+\item{...}{passed on to \code{\link[utils]{install.packages}}}
 }
 \description{
 It is vectorised so you can install multiple packages with

--- a/man/install_github.Rd
+++ b/man/install_github.Rd
@@ -31,7 +31,7 @@ the \code{GITHUB_PAT} environment variable.}
 \item{host}{GitHub API host to use. Override with your GitHub enterprise
 hostname, for example, \code{"github.hostname.com/api/v3"}.}
 
-\item{...}{Other arguments passed on to \code{install.packages}.}
+\item{...}{Other arguments passed on to \code{\link[utils]{install.packages}}.}
 }
 \description{
 This function is vectorised on \code{repo} so you can install multiple

--- a/man/install_local.Rd
+++ b/man/install_local.Rd
@@ -12,7 +12,7 @@ tar.bz2, tgz2 or tbz)}
 
 \item{subdir}{subdirectory within url bundle that contains the R package.}
 
-\item{...}{Other arguments passed on to \code{install.packages}.}
+\item{...}{Other arguments passed on to \code{\link[utils]{install.packages}}.}
 }
 \description{
 This function is vectorised so you can install multiple packages in

--- a/man/install_svn.Rd
+++ b/man/install_svn.Rd
@@ -16,7 +16,7 @@ package we are interested in installing.}
 \item{args}{A character vector providing extra options to pass on to
 \command{svn}.}
 
-\item{...}{Other arguments passed on to \code{install.packages}.}
+\item{...}{Other arguments passed on to \code{\link[utils]{install.packages}}.}
 
 \item{revision}{svn revision, if omitted updates to latest}
 }

--- a/man/install_url.Rd
+++ b/man/install_url.Rd
@@ -12,7 +12,7 @@ zip file, a tar file or a bzipped/gzipped tar file.}
 
 \item{subdir}{subdirectory within url bundle that contains the R package.}
 
-\item{...}{Other arguments passed on to \code{install.packages}.}
+\item{...}{Other arguments passed on to \code{\link[utils]{install.packages}}.}
 }
 \description{
 This function is vectorised so you can install multiple packages in

--- a/man/install_version.Rd
+++ b/man/install_version.Rd
@@ -12,7 +12,7 @@ install_version(package, version = NULL, repos = getOption("repos"),
 
 \item{version}{If the specified version is NULL or the same as the most
 recent version of the package, this function simply calls
-\code{install.packages}. Otherwise, it looks at the list of
+\code{\link[utils]{install.packages}}. Otherwise, it looks at the list of
 archived source tarballs and tries to install an older version instead.}
 
 \item{repos}{
@@ -30,7 +30,7 @@ archived source tarballs and tries to install an older version instead.}
     builds: see the section on \sQuote{Binary packages} for those.
   }
 
-\item{...}{Other arguments passed on to \code{install.packages}.}
+\item{...}{Other arguments passed on to \code{\link[utils]{install.packages}}.}
 }
 \description{
 If you are installing an package that contains compiled code, you will

--- a/man/update_packages.Rd
+++ b/man/update_packages.Rd
@@ -26,7 +26,7 @@ automatically to "binary" to avoid interactive prompts during package
 installation.}
 }
 \description{
-Works similarly to \code{install.packages()} but doesn't install packages
+Works similarly to \code{\link[utils]{install.packages}} but doesn't install packages
 that are already installed, and also upgrades out dated dependencies.
 }
 \examples{


### PR DESCRIPTION
use a `\code{\link[utils]{install.packages}}` everywhere in the documentation, so users can click on it to learn about its parameters