### PR TITLE
Ignore .Rbuildignore for install_local()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Suggests:
     git2r,
     mockery,
     pingr,
-    testthat,
+    testthat (>= 2.0.0),
     withr
 Depends:
     R (>= 3.0.0)

--- a/R/install-local.R
+++ b/R/install-local.R
@@ -33,10 +33,9 @@ remote_download.local_remote <- function(x, quiet = FALSE) {
   # Already downloaded - just need to copy to tempdir()
   bundle <- tempfile()
   dir.create(bundle)
-  file.copy(x$path, bundle, recursive = TRUE)
-
-  # file.copy() creates directory inside of bundle
-  dir(bundle, full.names = TRUE)[1]
+  target <- file.path(bundle, basename(x$path))
+  copy_without_rbuildignore(x$path, target)
+  normalizePath(target, winslash = "/", mustWork = TRUE)
 }
 
 #' @export

--- a/R/rbuildignore.R
+++ b/R/rbuildignore.R
@@ -1,5 +1,5 @@
 copy_without_rbuildignore <- function(source, target) {
-  if (!file.info(source)$isdir) {
+  if (!isTRUE(file.info(source)$isdir)) {
     return(file.copy(source, target))
   }
 

--- a/R/rbuildignore.R
+++ b/R/rbuildignore.R
@@ -1,0 +1,41 @@
+copy_without_rbuildignore <- function(source, target) {
+  if (!file.info(source)$isdir) {
+    return(file.copy(source, target))
+  }
+
+  exclude <- get_rbuildignore_exclusions(source)
+  copy_without_excluded(source, target, exclude)
+}
+
+get_rbuildignore_exclusions <- function(path) {
+  rbuildignore_path <- file.path(path, ".Rbuildignore")
+  if (file.exists(rbuildignore_path)) readLines(rbuildignore_path, warn = FALSE)
+  else character()
+}
+
+copy_without_excluded <- function(source, target, exclude) {
+  files <- dir(source, recursive = TRUE)
+  included_files <- get_files_from_exclude(files, exclude)
+  ret <- copy_files_deep(source, target, included_files)
+  stats::setNames(ret, included_files)
+}
+
+get_files_from_exclude <- function(files, exclude) {
+  if (length(exclude) > 0) {
+    exclude_rx <- paste0("(?:", exclude, ")", collapse = "|")
+    files[!grepl(exclude_rx, files, ignore.case = TRUE, perl = TRUE)]
+  } else {
+    files
+  }
+}
+
+copy_files_deep <- function(source, target, files) {
+  source_files <- file.path(source, files)
+  target_files <- file.path(target, files)
+
+  dirs <- unique(dirname(files))
+  target_dirs <- file.path(target, dirs)
+  lapply(target_dirs, dir.create, showWarnings = FALSE, recursive = TRUE)
+
+  file.copy(source_files, target_files)
+}

--- a/tests/testthat/test-rbuildignore.R
+++ b/tests/testthat/test-rbuildignore.R
@@ -1,0 +1,77 @@
+context("rbuildignore")
+
+get_all_combs <- function(x) {
+  if (length(x) == 0) list(x)
+  else {
+    sub_combs <- get_all_combs(x[-1])
+    c(sub_combs, lapply(sub_combs, function(sub) c(x[1], sub)))
+  }
+}
+
+test_that("helper for deep copying", {
+  N <- 4
+  combs <- get_all_combs(seq_len(N))
+  expect_length(combs, 2^N)
+  expect_true(all(table(unlist(combs)) == 2 ^ (N - 1)))
+  expect_equal(anyDuplicated(combs), 0)
+  expect_true(all(vapply(combs, length, integer(1)) <= N))
+})
+
+create_tempdir_with_files <- function() {
+  source <- tempfile()
+  dir.create(source)
+  withr::with_dir(
+    source,
+    {
+      dir.create("a")
+      dir.create("b/c", recursive = TRUE)
+      writeLines("root", "root.txt")
+      writeLines("a", "a/a.txt")
+      writeLines("b", "b/b.txt")
+      writeLines("c", "b/c/c.txt")
+    }
+  )
+  source
+}
+
+test_that("deep copying", {
+  source <- create_tempdir_with_files()
+  source_files <- dir(source, recursive = TRUE)
+
+  for (files in get_all_combs(source_files)) {
+    target <- tempfile()
+    dir.create(target)
+    expect_true(all(copy_files_deep(source, target, !! files)))
+    expect_setequal(dir(target, recursive = TRUE), !! files)
+  }
+})
+
+test_that("compute inclusions", {
+  source <- create_tempdir_with_files()
+  source_files <- dir(source, recursive = TRUE)
+
+  expect_setequal(
+    get_files_from_exclude(source_files, character()),
+    c("root.txt", "a/a.txt", "b/b.txt", "b/c/c.txt")
+  )
+
+  expect_setequal(
+    get_files_from_exclude(source_files, "^root.txt$"),
+    c("a/a.txt", "b/b.txt", "b/c/c.txt")
+  )
+
+  expect_setequal(
+    get_files_from_exclude(source_files, c("^root.txt$", "^b/b\\.txt$")),
+    c("a/a.txt", "b/c/c.txt")
+  )
+
+  expect_setequal(
+    get_files_from_exclude(source_files, "^a/"),
+    c("root.txt", "b/b.txt", "b/c/c.txt")
+  )
+
+  expect_setequal(
+    get_files_from_exclude(source_files, "^b/"),
+    c("root.txt", "a/a.txt")
+  )
+})


### PR DESCRIPTION
I forgot that `install_local()` is also supposed to work for `.tar.gz` files. Fixed now.

Updates (compared to merged and reverted state): https://github.com/r-lib/remotes/compare/a01d3c14324...krlmlr:f-%23107-rbuildignore-2