### PR TITLE
Install the latest release or a pull request for private repos

### DIFF
--- a/R/install-github.R
+++ b/R/install-github.R
@@ -157,6 +157,7 @@ remote_metadata.github_remote <- function(x, bundle = NULL, source = NULL) {
 #' Allows installing a specific pull request or the latest release.
 #'
 #' @param pull The pull request to install
+#' @param auth_token The personal access token (PAT)
 #' @seealso \code{\link{install_github}}
 #' @rdname github_refs
 #' @export

--- a/R/install-github.R
+++ b/R/install-github.R
@@ -60,7 +60,7 @@ github_remote <- function(repo, username = NULL, ref = NULL, subdir = NULL,
                        host = "api.github.com") {
 
   meta <- parse_git_repo(repo)
-  meta <- github_resolve_ref(meta$ref %||% ref, meta)
+  meta <- github_resolve_ref(meta$ref %||% ref, meta, auth_token)
 
   if (is.null(meta$username)) {
     meta$username <- username %||% getOption("github.user") %||%
@@ -166,26 +166,26 @@ github_pull <- function(pull) structure(pull, class = "github_pull")
 #' @export
 github_release <- function() structure(NA_integer_, class = "github_release")
 
-github_resolve_ref <- function(x, params) UseMethod("github_resolve_ref")
+github_resolve_ref <- function(x, params, auth_token) UseMethod("github_resolve_ref")
 
 #' @export
-github_resolve_ref.default <- function(x, params) {
+github_resolve_ref.default <- function(x, params, auth_token) {
   params$ref <- x
   params
 }
 
 #' @export
-github_resolve_ref.NULL <- function(x, params) {
+github_resolve_ref.NULL <- function(x, params, auth_token) {
   params$ref <- "master"
   params
 }
 
 #' @export
-github_resolve_ref.github_pull <- function(x, params) {
+github_resolve_ref.github_pull <- function(x, params, auth_token) {
   # GET /repos/:user/:repo/pulls/:number
   path <- file.path("repos", params$username, params$repo, "pulls", x)
   response <- tryCatch(
-    github_GET(path),
+    github_GET(path, pat = auth_token),
     error = function(e) e
   )
 
@@ -202,11 +202,11 @@ github_resolve_ref.github_pull <- function(x, params) {
 
 # Retrieve the ref for the latest release
 #' @export
-github_resolve_ref.github_release <- function(x, params) {
+github_resolve_ref.github_release <- function(x, params, auth_token) {
   # GET /repos/:user/:repo/releases
   path <- paste("repos", params$username, params$repo, "releases", sep = "/")
   response <- tryCatch(
-    github_GET(path),
+    github_GET(path, pat = auth_token),
     error = function(e) e
   )
 

--- a/man/github_refs.Rd
+++ b/man/github_refs.Rd
@@ -11,6 +11,8 @@ github_release()
 }
 \arguments{
 \item{pull}{The pull request to install}
+
+\item{auth_token}{The personal access token (PAT)}
 }
 \description{
 Use as \code{ref} parameter to \code{\link{install_github}}.


### PR DESCRIPTION
Hi,
I modified `github_resolve_ref()` as it was not using the auth_token argument when installing the latest release or a pull request (it was working only if the token was setup as an env variable).