### PR TITLE
Proof of concept for using curl with multiple requests

### DIFF
--- a/R/deps.R
+++ b/R/deps.R
@@ -269,8 +269,11 @@ update.package_deps <- function(object, ..., quiet = FALSE, upgrade = TRUE) {
   }
 
   if (any(object$is_cran & behind)) {
-    install_packages(object$package[object$is_cran & behind], repos = attr(object, "repos"),
-      type = attr(object, "type"), ...)
+    to_install <- object$is_cran & behind
+    dest <- tempfile()
+    dir.create(dest)
+    res <- download_packages(object$package[to_install], dest, repos = attr(object, "repos"), type = "binary", versions = object$available[to_install])
+    install_packages(res[, 2], repos = NULL, type = "binary")
   }
 
   install_remotes(object$remote[!object$is_cran & behind], ..., quiet = quiet, upgrade = upgrade)


### PR DESCRIPTION
As a partial solution to #34 we could download all CRAN dependencies in parallel, then install them; we already have the full list of CRAN dependencies when we update them. This doesn't do anything for Remotes dependencies, but maybe that is ok.

As a simple test if this is worthwhile I used `download.packages()` to download binaries for all the dplyr CRAN dependencies, which ends up being 69 packages on my machine and the same thing with `download_packages()`

``` r
devtools::load_all("~/p/remotes")
#> Loading remotes
deps <- remotes::package_deps("dplyr", dependencies = TRUE)
deps <- deps[deps$is_cran, ]

out <- tempfile()
dir.create(out)
system.time(download.packages(deps$package, out, type = "binary"))
#>    user  system elapsed 
#>  10.897   1.404  59.585

out2 <- tempfile()
dir.create(out2)
system.time(download_packages(deps$package, out2, versions = deps$available, type = "binary"))
#> downloaded bindr_0.1.1.tgz:200
#> downloaded base64enc_0.1-3.tgz:200
#> downloaded assertthat_0.2.0.tgz:200
# (sic)
#>    user  system elapsed 
#>   0.437   0.766   6.024

expect_equal(list.files(out), list.files(out2))
```

Created on 2018-09-05 by the [reprex package](http://reprex.tidyverse.org) (v0.2.0).

So at least in this scenario there is a substantial savings from the async downloads.

However there are still some things to be addressed including

1. `download.packages(type = "binary")` downloads the source package, so we would need to replicate code in `install.packages()` that determines whether a binary package is available.
2. Local `file:://` repositories are not currently addressed.
3. The current implementation does not handle all all the package types, it is hardcoded for mac binaries.
4. We would need to fallback to `download.packages()` if curl is not available.
5. We lose the individual progress bars while a download is running.

So @gaborcsardi my question is do you think it is worth the investment to fix the above deficiencies?