### PR TITLE
fix internal remotes:::untar wrapper for Windows platforms

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -157,10 +157,10 @@ with_rprofile_user <- function(new, code) {
 
 untar <- function(tarfile, ...) {
   if (os_type() == "windows") {
-    tryCatch(
-      utils::untar(tarfile, extras = "--force-local", ...),
-      warning = function(e) utils::untar(tarfile, ...)
-    )
+    status <- try(utils::untar(tarfile, extras = "--force-local", ...))
+    if(inherits(status, "try-error") || status != 0){
+        utils::untar(tarfile, ...)
+    }
 
   } else {
     utils::untar(tarfile, ...)

--- a/R/utils.R
+++ b/R/utils.R
@@ -159,7 +159,7 @@ untar <- function(tarfile, ...) {
   if (os_type() == "windows") {
     tryCatch(
       utils::untar(tarfile, extras = "--force-local", ...),
-      error = function(e) utils::untar(tarfile, ...)
+      warning = function(e) utils::untar(tarfile, ...)
     )
 
   } else {

--- a/R/utils.R
+++ b/R/utils.R
@@ -160,8 +160,9 @@ untar <- function(tarfile, ...) {
     status <- try(utils::untar(tarfile, extras = "--force-local", ...))
     if(inherits(status, "try-error") || status != 0){
         utils::untar(tarfile, ...)
+    } else {
+        status
     }
-
   } else {
     utils::untar(tarfile, ...)
   }


### PR DESCRIPTION
utils::untar returns a warning when it fails but the tryCatch in remotes:::untar expects an error. 
Therefore the alternative untar without  extras="--force-local" is not triggered when it should be and the installation from a tarball fails.

tryCatch was modified to expect a warning instead.

