### PR TITLE
Remove `threads` arg of `install_deps()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,9 @@
 * `install_github()`'s previously deprecated `username` argument has been
   removed. (#142)
 
+* `install_deps()`'s `threads` argument has been removed, use the `Ncpus`
+  argument instead (#153, #154)
+
 # Development
 
 * Remotes can be forced to use only its internal code by setting the

--- a/R/install.R
+++ b/R/install.R
@@ -102,8 +102,6 @@ safe_build_package <- function(pkgdir, build_opts, dest_path, quiet, use_pkgbuil
 #' Install package dependencies if needed.
 #'
 #' @inheritParams package_deps
-#' @param threads Number of threads to start, passed to
-#'   \code{\link[utils]{install.packages}} as \code{Ncpus}.
 #' @param ... additional arguments passed to \code{\link[utils]{install.packages}}.
 #' @param build If \code{TRUE} build the pacakge before installing.
 #' @param build_opts Options to pass to `R CMD build`.
@@ -112,7 +110,6 @@ safe_build_package <- function(pkgdir, build_opts, dest_path, quiet, use_pkgbuil
 #' \dontrun{install_deps(".")}
 
 install_deps <- function(pkgdir = ".", dependencies = NA,
-                         threads = getOption("Ncpus", 1),
                          repos = getOption("repos"),
                          type = getOption("pkgType"),
                          ...,
@@ -135,7 +132,6 @@ install_deps <- function(pkgdir = ".", dependencies = NA,
     packages,
     dependencies = dep_deps,
     ...,
-    Ncpus = threads,
     quiet = quiet,
     upgrade = upgrade,
     build = build,

--- a/man/install_deps.Rd
+++ b/man/install_deps.Rd
@@ -5,9 +5,9 @@
 \title{Install package dependencies if needed.}
 \usage{
 install_deps(pkgdir = ".", dependencies = NA,
-  threads = getOption("Ncpus", 1), repos = getOption("repos"),
-  type = getOption("pkgType"), ..., upgrade = TRUE, quiet = FALSE,
-  build = TRUE, build_opts = c("--no-resave-data", "--no-manual",
+  repos = getOption("repos"), type = getOption("pkgType"), ...,
+  upgrade = TRUE, quiet = FALSE, build = TRUE,
+  build_opts = c("--no-resave-data", "--no-manual",
   "--no-build-vignettes"))
 }
 \arguments{
@@ -21,9 +21,6 @@ install_deps(pkgdir = ".", dependencies = NA,
   "Suggests". \code{NA} is shorthand for "Depends", "Imports" and "LinkingTo"
   and is the default. \code{FALSE} is shorthand for no dependencies (i.e.
   just check this package, not its dependencies).}
-
-\item{threads}{Number of threads to start, passed to
-\code{\link[utils]{install.packages}} as \code{Ncpus}.}
 
 \item{repos}{A character vector giving repositories to use.}
 


### PR DESCRIPTION
If `Ncpus` was also specified, that led to an error.
Closes #153.