### PR TITLE
Expose all installation options to all install functions

### DIFF
--- a/R/install-bioc.R
+++ b/R/install-bioc.R
@@ -15,6 +15,7 @@
 #'   numbers (e.g. \sQuote{3.3}).
 #' @param mirror The bioconductor git mirror to use
 #' @param ... Other arguments passed on to [utils::install.packages()].
+#' @inheritParams install_github
 #' @export
 #' @family package installation
 #' @examples
@@ -28,11 +29,28 @@
 #' install_bioc("user:password@SummarizedExperiment#abc123")
 #'}
 install_bioc <- function(repo, mirror = getOption("BioC_git", download_url("git.bioconductor.org/packages")),
-  git = c("auto", "git2r", "external"), ...) {
+                         git = c("auto", "git2r", "external"),
+                         dependencies = NA,
+                         upgrade = TRUE,
+                         force = FALSE,
+                         quiet = FALSE,
+                         build = TRUE, build_opts = c("--no-resave-data", "--no-manual", "--no-build-vignettes"),
+                         repos = getOption("repos"),
+                         type = getOption("pkgType"),
+                         ...) {
 
   remotes <- lapply(repo, bioc_remote, mirror = mirror, git = match.arg(git))
 
-  install_remotes(remotes, ...)
+  install_remotes(remotes,
+                  dependencies = dependencies,
+                  upgrade = upgrade,
+                  force = force,
+                  quiet = quiet,
+                  build = build,
+                  build_opts = build_opts,
+                  repos = repos,
+                  type = type,
+                  ...)
 }
 
 bioc_remote <- function(repo, mirror = getOption("BioC_git", download_url("git.bioconductor.org/packages")),

--- a/R/install-bitbucket.R
+++ b/R/install-bitbucket.R
@@ -25,6 +25,7 @@
 #' App Passwords documentation}. The App Password requires read-only access to
 #' your repositories and pull requests. Then store your password in the
 #' environment variable `BITBUCKET_PASSWORD` (e.g. `evelynwaugh:swordofhonour`)
+#' @inheritParams install_github
 #' @export
 #' @examples
 #' \dontrun{
@@ -33,12 +34,29 @@
 #' }
 install_bitbucket <- function(repo, ref = "master", subdir = NULL,
                               auth_user = bitbucket_user(), password = bitbucket_password(),
-                              host = "api.bitbucket.org/2.0", ...) {
+                              host = "api.bitbucket.org/2.0",
+                              dependencies = NA,
+                              upgrade = TRUE,
+                              force = FALSE,
+                              quiet = FALSE,
+                              build = TRUE, build_opts = c("--no-resave-data", "--no-manual", "--no-build-vignettes"),
+                              repos = getOption("repos"),
+                              type = getOption("pkgType"),
+                              ...) {
 
   remotes <- lapply(repo, bitbucket_remote, ref = ref,
     subdir = subdir, auth_user = auth_user, password = password, host = host)
 
-  install_remotes(remotes, auth_user = auth_user, password = password, host = host, ...)
+  install_remotes(remotes, auth_user = auth_user, password = password, host = host,
+                  dependencies = dependencies,
+                  upgrade = upgrade,
+                  force = force,
+                  quiet = quiet,
+                  build = build,
+                  build_opts = build_opts,
+                  repos = repos,
+                  type = type,
+                  ...)
 }
 
 bitbucket_remote <- function(repo, ref = "master", subdir = NULL,

--- a/R/install-cran.R
+++ b/R/install-cran.R
@@ -5,7 +5,7 @@
 #' packages in a single command.
 #'
 #' @param pkgs Character vector of packages to install.
-#' @inheritParams package_deps
+#' @inheritParams install_github
 #' @export
 #' @family package installation
 #' @examples
@@ -13,11 +13,26 @@
 #' install_cran("ggplot2")
 #' install_cran(c("httpuv", "shiny"))
 #' }
-install_cran <- function(pkgs, repos = getOption("repos"), type = getOption("pkgType"), ..., quiet = FALSE) {
+install_cran <- function(pkgs, repos = getOption("repos"), type = getOption("pkgType"),
+                         dependencies = NA,
+                         upgrade = TRUE,
+                         force = FALSE,
+                         quiet = FALSE,
+                         build = TRUE, build_opts = c("--no-resave-data", "--no-manual", "--no-build-vignettes"),
+                         ...) {
 
   remotes <- lapply(pkgs, cran_remote, repos = repos, type = type)
 
-  install_remotes(remotes, quiet = quiet, ...)
+  install_remotes(remotes,
+                  dependencies = dependencies,
+                  upgrade = upgrade,
+                  force = force,
+                  quiet = quiet,
+                  build = build,
+                  build_opts = build_opts,
+                  repos = repos,
+                  type = type,
+                  ...)
 }
 
 cran_remote <- function(pkg, repos, type, ...) {

--- a/R/install-git.R
+++ b/R/install-git.R
@@ -16,6 +16,7 @@
 #'   git client via system. Default is `git2r` if it is installed,
 #'   otherwise an external git installation.
 #' @param ... Other arguments passed on to [utils::install.packages()].
+#' @inheritParams install_github
 #' @export
 #' @examples
 #' \dontrun{
@@ -23,12 +24,29 @@
 #' install_git("git://github.com/hadley/stringr.git", branch = "stringr-0.2")
 #'}
 install_git <- function(url, subdir = NULL, branch = NULL, credentials = NULL,
-                        git = c("auto", "git2r", "external"), ...) {
+                        git = c("auto", "git2r", "external"),
+                        dependencies = NA,
+                        upgrade = TRUE,
+                        force = FALSE,
+                        quiet = FALSE,
+                        build = TRUE, build_opts = c("--no-resave-data", "--no-manual", "--no-build-vignettes"),
+                        repos = getOption("repos"),
+                        type = getOption("pkgType"),
+                        ...) {
 
   remotes <- lapply(url, git_remote, subdir = subdir, branch = branch,
     credentials = credentials, git = match.arg(git))
 
-  install_remotes(remotes, credentials = credentials, ...)
+  install_remotes(remotes, credentials = credentials,
+                  dependencies = dependencies,
+                  upgrade = upgrade,
+                  force = force,
+                  quiet = quiet,
+                  build = build,
+                  build_opts = build_opts,
+                  repos = repos,
+                  type = type,
+                  ...)
 }
 
 

--- a/R/install-github.R
+++ b/R/install-github.R
@@ -18,6 +18,9 @@
 #'   the `GITHUB_PAT` environment variable.
 #' @param host GitHub API host to use. Override with your GitHub enterprise
 #'   hostname, for example, `"github.hostname.com/api/v3"`.
+#' @param force Force installation, even if the remote state has not changed
+#'   since the previous install.
+#' @inheritParams install_deps
 #' @param ... Other arguments passed on to [utils::install.packages()].
 #' @details
 #' If the repository uses submodules a command-line git client is required to
@@ -40,14 +43,32 @@
 #'
 #' }
 install_github <- function(repo,
-                           ref = "master", subdir = NULL,
+                           ref = "master",
+                           subdir = NULL,
                            auth_token = github_pat(),
-                           host = "api.github.com", ...) {
+                           host = "api.github.com",
+                           dependencies = NA,
+                           upgrade = TRUE,
+                           force = FALSE,
+                           quiet = FALSE,
+                           build = TRUE, build_opts = c("--no-resave-data", "--no-manual", "--no-build-vignettes"),
+                           repos = getOption("repos"),
+                           type = getOption("pkgType"),
+                           ...) {
 
   remotes <- lapply(repo, github_remote, ref = ref,
     subdir = subdir, auth_token = auth_token, host = host)
 
-  install_remotes(remotes, auth_token = auth_token, host = host, ...)
+  install_remotes(remotes, auth_token = auth_token, host = host,
+    dependencies = dependencies,
+    upgrade = upgrade,
+    force = force,
+    quiet = quiet,
+    build = build,
+    build_opts = build_opts,
+    repos = repos,
+    type = type,
+    ...)
 }
 
 github_remote <- function(repo, ref = "master", subdir = NULL,

--- a/R/install-gitlab.R
+++ b/R/install-gitlab.R
@@ -10,6 +10,7 @@
 #'   `username/repo[/subdir][@@ref]`.
 #' @param host GitLab API host to use. Override with your GitLab enterprise
 #'   hostname, for example, `"gitlab.hostname.com"`.
+#' @inheritParams install_github
 #' @export
 #' @family package installation
 #' @examples
@@ -18,12 +19,28 @@
 #' }
 install_gitlab <- function(repo,
                            auth_token = gitlab_pat(),
-                           host = "gitlab.com", ...)
-{
+                           host = "gitlab.com",
+                           dependencies = NA,
+                           upgrade = TRUE,
+                           force = FALSE,
+                           quiet = FALSE,
+                           build = TRUE, build_opts = c("--no-resave-data", "--no-manual", "--no-build-vignettes"),
+                           repos = getOption("repos"),
+                           type = getOption("pkgType"),
+                           ...) {
 
   remotes <- lapply(repo, gitlab_remote, auth_token = auth_token, host = host)
 
-  install_remotes(remotes, auth_token = auth_token, host = host, ...)
+  install_remotes(remotes, auth_token = auth_token, host = host,
+                  dependencies = dependencies,
+                  upgrade = upgrade,
+                  force = force,
+                  quiet = quiet,
+                  build = build,
+                  build_opts = build_opts,
+                  repos = repos,
+                  type = type,
+                  ...)
 }
 
 gitlab_remote <- function(repo,

--- a/R/install-local.R
+++ b/R/install-local.R
@@ -7,6 +7,7 @@
 #' @param path path to local directory, or compressed file (tar, zip, tar.gz
 #'   tar.bz2, tgz2 or tbz)
 #' @inheritParams install_url
+#' @inheritParams install_github
 #' @export
 #' @examples
 #' \dontrun{
@@ -16,9 +17,27 @@
 #' install_local(pkg[, 2])
 #' }
 
-install_local <- function(path, subdir = NULL, ...) {
+install_local <- function(path, subdir = NULL,
+                           dependencies = NA,
+                           upgrade = TRUE,
+                           force = FALSE,
+                           quiet = FALSE,
+                           build = TRUE, build_opts = c("--no-resave-data", "--no-manual", "--no-build-vignettes"),
+                           repos = getOption("repos"),
+                           type = getOption("pkgType"),
+                           ...) {
+
   remotes <- lapply(path, local_remote, subdir = subdir)
-  install_remotes(remotes, ...)
+  install_remotes(remotes,
+                  dependencies = dependencies,
+                  upgrade = upgrade,
+                  force = force,
+                  quiet = quiet,
+                  build = build,
+                  build_opts = build_opts,
+                  repos = repos,
+                  type = type,
+                  ...)
 }
 
 local_remote <- function(path, subdir = NULL, branch = NULL, args = character(0), ...) {

--- a/R/install-remote.R
+++ b/R/install-remote.R
@@ -8,7 +8,17 @@
 #'   \item calls install
 #' }
 #' @noRd
-install_remote <- function(remote, ..., force = FALSE, quiet = FALSE) {
+install_remote <- function(remote,
+                           dependencies = dependencies,
+                           upgrade = upgrade,
+                           force = force,
+                           quiet = quiet,
+                           build = build,
+                           build_opts = build_opts,
+                           repos = repos,
+                           type = type,
+                           ...) {
+
   stopifnot(is.remote(remote))
 
   package_name <- remote_package_name(remote)
@@ -47,7 +57,16 @@ install_remote <- function(remote, ..., force = FALSE, quiet = FALSE) {
   # Because we've modified DESCRIPTION, its original MD5 value is wrong
   clear_description_md5(source)
 
-  install(source, ..., quiet = quiet)
+  install(source,
+          dependencies = dependencies,
+          upgrade = upgrade,
+          force = force,
+          quiet = quiet,
+          build = build,
+          build_opts = build_opts,
+          repos = repos,
+          type = type,
+          ...)
 }
 
 install_remotes <- function(remotes, ...) {

--- a/R/install-svn.R
+++ b/R/install-svn.R
@@ -14,6 +14,7 @@
 #'   \command{svn}.
 #' @param revision svn revision, if omitted updates to latest
 #' @param ... Other arguments passed on to [utils::install.packages()].
+#' @inheritParams install_github
 #' @export
 #'
 #' @examples
@@ -22,12 +23,29 @@
 #' install_svn("https://github.com/hadley/httr/branches/oauth")
 #'}
 install_svn <- function(url, subdir = NULL, args = character(0),
-  ..., revision = NULL) {
+                        revision = NULL,
+                        dependencies = NA,
+                        upgrade = TRUE,
+                        force = FALSE,
+                        quiet = FALSE,
+                        build = TRUE, build_opts = c("--no-resave-data", "--no-manual", "--no-build-vignettes"),
+                        repos = getOption("repos"),
+                        type = getOption("pkgType"),
+                        ...) {
 
   remotes <- lapply(url, svn_remote, svn_subdir = subdir,
     revision = revision, args = args)
 
-  install_remotes(remotes, args = args, ...)
+  install_remotes(remotes, args = args,
+                  dependencies = dependencies,
+                  upgrade = upgrade,
+                  force = force,
+                  quiet = quiet,
+                  build = build,
+                  build_opts = build_opts,
+                  repos = repos,
+                  type = type,
+                  ...)
 }
 
 svn_remote <- function(url, svn_subdir = NULL, revision = NULL,

--- a/R/install-url.R
+++ b/R/install-url.R
@@ -8,6 +8,7 @@
 #'   zip file, a tar file or a bzipped/gzipped tar file.
 #' @param subdir subdirectory within url bundle that contains the R package.
 #' @param ... Other arguments passed on to [utils::install.packages()].
+#' @inheritParams install_github
 #' @export
 #'
 #' @examples
@@ -15,9 +16,26 @@
 #' install_url("https://github.com/hadley/stringr/archive/master.zip")
 #' }
 
-install_url <- function(url, subdir = NULL, ...) {
+install_url <- function(url, subdir = NULL,
+                        dependencies = NA,
+                        upgrade = TRUE,
+                        force = FALSE,
+                        quiet = FALSE,
+                        build = TRUE, build_opts = c("--no-resave-data", "--no-manual", "--no-build-vignettes"),
+                        repos = getOption("repos"),
+                        type = getOption("pkgType"),
+                        ...) {
   remotes <- lapply(url, url_remote, subdir = subdir)
-  install_remotes(remotes, ...)
+  install_remotes(remotes,
+                  dependencies = dependencies,
+                  upgrade = upgrade,
+                  force = force,
+                  quiet = quiet,
+                  build = build,
+                  build_opts = build_opts,
+                  repos = repos,
+                  type = type,
+                  ...)
 }
 
 url_remote <- function(url, subdir = NULL, ...) {

--- a/R/install-version.R
+++ b/R/install-version.R
@@ -15,13 +15,31 @@
 #'   archived source tarballs and tries to install an older version instead.
 #' @param ... Other arguments passed on to [utils::install.packages()].
 #' @inheritParams utils::install.packages
+#' @inheritParams install_github
 #' @author Jeremy Stephens
 #' @importFrom utils available.packages contrib.url install.packages
 
-install_version <- function(package, version = NULL, repos = getOption("repos"), type = getOption("pkgType"), ...) {
+install_version <- function(package, version = NULL,
+                            dependencies = NA,
+                            upgrade = TRUE,
+                            force = FALSE,
+                            quiet = FALSE,
+                            build = TRUE, build_opts = c("--no-resave-data", "--no-manual", "--no-build-vignettes"),
+                            repos = getOption("repos"),
+                            type = getOption("pkgType"),
+                            ...) {
 
   url <- download_version_url(package, version, repos, type)
-  install_url(url, ...)
+  install_url(url,
+              dependencies = dependencies,
+              upgrade = upgrade,
+              force = force,
+              quiet = quiet,
+              build = build,
+              build_opts = build_opts,
+              repos = repos,
+              type = type,
+              ...)
 }
 
 package_find_repo <- function(package, repos) {

--- a/R/install.R
+++ b/R/install.R
@@ -1,7 +1,5 @@
-
-install <- function(pkgdir = ".", dependencies = NA, quiet = TRUE, build =
-  TRUE, build_opts = c("--no-resave-data", "--no-manual", "--no-build-vignettes"), ..., repos =
-  getOption("repos")) {
+install <- function(pkgdir, dependencies, quiet, build, build_opts, upgrade,
+                    repos, type, ...) {
 
   if (file.exists(file.path(pkgdir, "src")) && ! has_devel()) {
     missing_devel_warning(pkgdir)
@@ -15,7 +13,7 @@ install <- function(pkgdir = ".", dependencies = NA, quiet = TRUE, build =
   }
 
   install_deps(pkgdir, dependencies = dependencies, quiet = quiet,
-    build = build, build_opts = build_opts, repos = repos, ...)
+    build = build, build_opts = build_opts, repos = repos, type = type, ...)
 
   if (isTRUE(build)) {
     dir <- tempfile()
@@ -103,8 +101,9 @@ safe_build_package <- function(pkgdir, build_opts, dest_path, quiet, use_pkgbuil
 #'
 #' @inheritParams package_deps
 #' @param ... additional arguments passed to [utils::install.packages()].
-#' @param build If `TRUE` build the pacakge before installing.
-#' @param build_opts Options to pass to `R CMD build`.
+#' @param build If `TRUE` build the package before installing.
+#' @param build_opts Options to pass to `R CMD build`, only used when `build`
+#' is `TRUE`.
 #' @export
 #' @examples
 #' \dontrun{install_deps(".")}
@@ -112,11 +111,11 @@ safe_build_package <- function(pkgdir, build_opts, dest_path, quiet, use_pkgbuil
 install_deps <- function(pkgdir = ".", dependencies = NA,
                          repos = getOption("repos"),
                          type = getOption("pkgType"),
-                         ...,
                          upgrade = TRUE,
                          quiet = FALSE,
                          build = TRUE,
-                         build_opts = c("--no-resave-data", "--no-manual", "--no-build-vignettes")) {
+                         build_opts = c("--no-resave-data", "--no-manual", "--no-build-vignettes"),
+                         ...) {
 
   packages <- dev_package_deps(
     pkgdir,
@@ -131,10 +130,10 @@ install_deps <- function(pkgdir = ".", dependencies = NA,
   update(
     packages,
     dependencies = dep_deps,
-    ...,
     quiet = quiet,
     upgrade = upgrade,
     build = build,
-    build_opts = build_opts
+    build_opts = build_opts,
+    ...
   )
 }

--- a/man/install_bioc.Rd
+++ b/man/install_bioc.Rd
@@ -6,7 +6,11 @@
 \usage{
 install_bioc(repo, mirror = getOption("BioC_git",
   download_url("git.bioconductor.org/packages")), git = c("auto",
-  "git2r", "external"), ...)
+  "git2r", "external"), dependencies = NA, upgrade = TRUE,
+  force = FALSE, quiet = FALSE, build = TRUE,
+  build_opts = c("--no-resave-data", "--no-manual",
+  "--no-build-vignettes"), repos = getOption("repos"),
+  type = getOption("pkgType"), ...)
 }
 \arguments{
 \item{repo}{Repository address in the format
@@ -20,6 +24,31 @@ numbers (e.g. \sQuote{3.3}).}
 \item{git}{Whether to use the \code{git2r} package, or an external
 git client via system. Default is \code{git2r} if it is installed,
 otherwise an external git installation.}
+
+\item{dependencies}{Which dependencies do you want to check?
+Can be a character vector (selecting from "Depends", "Imports",
+"LinkingTo", "Suggests", or "Enhances"), or a logical vector.
+
+\code{TRUE} is shorthand for "Depends", "Imports", "LinkingTo" and
+"Suggests". \code{NA} is shorthand for "Depends", "Imports" and "LinkingTo"
+and is the default. \code{FALSE} is shorthand for no dependencies (i.e.
+just check this package, not its dependencies).}
+
+\item{upgrade}{If \code{TRUE}, also upgrade any of out date dependencies.}
+
+\item{force}{Force installation, even if the remote state has not changed
+since the previous install.}
+
+\item{quiet}{If \code{TRUE}, suppress output.}
+
+\item{build}{If \code{TRUE} build the package before installing.}
+
+\item{build_opts}{Options to pass to \code{R CMD build}, only used when \code{build}
+is \code{TRUE}.}
+
+\item{repos}{A character vector giving repositories to use.}
+
+\item{type}{Type of package to \code{update}.}
 
 \item{...}{Other arguments passed on to \code{\link[utils:install.packages]{utils::install.packages()}}.}
 }

--- a/man/install_bitbucket.Rd
+++ b/man/install_bitbucket.Rd
@@ -6,7 +6,11 @@
 \usage{
 install_bitbucket(repo, ref = "master", subdir = NULL,
   auth_user = bitbucket_user(), password = bitbucket_password(),
-  host = "api.bitbucket.org/2.0", ...)
+  host = "api.bitbucket.org/2.0", dependencies = NA, upgrade = TRUE,
+  force = FALSE, quiet = FALSE, build = TRUE,
+  build_opts = c("--no-resave-data", "--no-manual",
+  "--no-build-vignettes"), repos = getOption("repos"),
+  type = getOption("pkgType"), ...)
 }
 \arguments{
 \item{repo}{Repository address in the format
@@ -31,6 +35,31 @@ up a password.}
 
 \item{host}{GitHub API host to use. Override with your GitHub enterprise
 hostname, for example, \code{"github.hostname.com/api/v3"}.}
+
+\item{dependencies}{Which dependencies do you want to check?
+Can be a character vector (selecting from "Depends", "Imports",
+"LinkingTo", "Suggests", or "Enhances"), or a logical vector.
+
+\code{TRUE} is shorthand for "Depends", "Imports", "LinkingTo" and
+"Suggests". \code{NA} is shorthand for "Depends", "Imports" and "LinkingTo"
+and is the default. \code{FALSE} is shorthand for no dependencies (i.e.
+just check this package, not its dependencies).}
+
+\item{upgrade}{If \code{TRUE}, also upgrade any of out date dependencies.}
+
+\item{force}{Force installation, even if the remote state has not changed
+since the previous install.}
+
+\item{quiet}{If \code{TRUE}, suppress output.}
+
+\item{build}{If \code{TRUE} build the package before installing.}
+
+\item{build_opts}{Options to pass to \code{R CMD build}, only used when \code{build}
+is \code{TRUE}.}
+
+\item{repos}{A character vector giving repositories to use.}
+
+\item{type}{Type of package to \code{update}.}
 
 \item{...}{Other arguments passed on to \code{\link[utils:install.packages]{utils::install.packages()}}.}
 }

--- a/man/install_cran.Rd
+++ b/man/install_cran.Rd
@@ -5,7 +5,10 @@
 \title{Attempts to install a package from CRAN.}
 \usage{
 install_cran(pkgs, repos = getOption("repos"),
-  type = getOption("pkgType"), ..., quiet = FALSE)
+  type = getOption("pkgType"), dependencies = NA, upgrade = TRUE,
+  force = FALSE, quiet = FALSE, build = TRUE,
+  build_opts = c("--no-resave-data", "--no-manual",
+  "--no-build-vignettes"), ...)
 }
 \arguments{
 \item{pkgs}{Character vector of packages to install.}
@@ -14,9 +17,28 @@ install_cran(pkgs, repos = getOption("repos"),
 
 \item{type}{Type of package to \code{update}.}
 
-\item{...}{Additional arguments passed to \code{install_packages}.}
+\item{dependencies}{Which dependencies do you want to check?
+Can be a character vector (selecting from "Depends", "Imports",
+"LinkingTo", "Suggests", or "Enhances"), or a logical vector.
+
+\code{TRUE} is shorthand for "Depends", "Imports", "LinkingTo" and
+"Suggests". \code{NA} is shorthand for "Depends", "Imports" and "LinkingTo"
+and is the default. \code{FALSE} is shorthand for no dependencies (i.e.
+just check this package, not its dependencies).}
+
+\item{upgrade}{If \code{TRUE}, also upgrade any of out date dependencies.}
+
+\item{force}{Force installation, even if the remote state has not changed
+since the previous install.}
 
 \item{quiet}{If \code{TRUE}, suppress output.}
+
+\item{build}{If \code{TRUE} build the package before installing.}
+
+\item{build_opts}{Options to pass to \code{R CMD build}, only used when \code{build}
+is \code{TRUE}.}
+
+\item{...}{Other arguments passed on to \code{\link[utils:install.packages]{utils::install.packages()}}.}
 }
 \description{
 This function is vectorised on \code{pkgs} so you can install multiple

--- a/man/install_deps.Rd
+++ b/man/install_deps.Rd
@@ -5,10 +5,10 @@
 \title{Install package dependencies if needed.}
 \usage{
 install_deps(pkgdir = ".", dependencies = NA,
-  repos = getOption("repos"), type = getOption("pkgType"), ...,
+  repos = getOption("repos"), type = getOption("pkgType"),
   upgrade = TRUE, quiet = FALSE, build = TRUE,
   build_opts = c("--no-resave-data", "--no-manual",
-  "--no-build-vignettes"))
+  "--no-build-vignettes"), ...)
 }
 \arguments{
 \item{pkgdir}{path to a package directory, or to a package tarball.}
@@ -26,15 +26,16 @@ just check this package, not its dependencies).}
 
 \item{type}{Type of package to \code{update}.}
 
-\item{...}{additional arguments passed to \code{\link[utils:install.packages]{utils::install.packages()}}.}
-
 \item{upgrade}{If \code{TRUE}, also upgrade any of out date dependencies.}
 
 \item{quiet}{If \code{TRUE}, suppress output.}
 
-\item{build}{If \code{TRUE} build the pacakge before installing.}
+\item{build}{If \code{TRUE} build the package before installing.}
 
-\item{build_opts}{Options to pass to \code{R CMD build}.}
+\item{build_opts}{Options to pass to \code{R CMD build}, only used when \code{build}
+is \code{TRUE}.}
+
+\item{...}{additional arguments passed to \code{\link[utils:install.packages]{utils::install.packages()}}.}
 }
 \description{
 Install package dependencies if needed.

--- a/man/install_git.Rd
+++ b/man/install_git.Rd
@@ -5,7 +5,11 @@
 \title{Install a package from a git repository}
 \usage{
 install_git(url, subdir = NULL, branch = NULL, credentials = NULL,
-  git = c("auto", "git2r", "external"), ...)
+  git = c("auto", "git2r", "external"), dependencies = NA,
+  upgrade = TRUE, force = FALSE, quiet = FALSE, build = TRUE,
+  build_opts = c("--no-resave-data", "--no-manual",
+  "--no-build-vignettes"), repos = getOption("repos"),
+  type = getOption("pkgType"), ...)
 }
 \arguments{
 \item{url}{Location of package. The url should point to a public or
@@ -22,6 +26,31 @@ Supplying this argument implies using \code{git2r} with \code{git}.}
 \item{git}{Whether to use the \code{git2r} package, or an external
 git client via system. Default is \code{git2r} if it is installed,
 otherwise an external git installation.}
+
+\item{dependencies}{Which dependencies do you want to check?
+Can be a character vector (selecting from "Depends", "Imports",
+"LinkingTo", "Suggests", or "Enhances"), or a logical vector.
+
+\code{TRUE} is shorthand for "Depends", "Imports", "LinkingTo" and
+"Suggests". \code{NA} is shorthand for "Depends", "Imports" and "LinkingTo"
+and is the default. \code{FALSE} is shorthand for no dependencies (i.e.
+just check this package, not its dependencies).}
+
+\item{upgrade}{If \code{TRUE}, also upgrade any of out date dependencies.}
+
+\item{force}{Force installation, even if the remote state has not changed
+since the previous install.}
+
+\item{quiet}{If \code{TRUE}, suppress output.}
+
+\item{build}{If \code{TRUE} build the package before installing.}
+
+\item{build_opts}{Options to pass to \code{R CMD build}, only used when \code{build}
+is \code{TRUE}.}
+
+\item{repos}{A character vector giving repositories to use.}
+
+\item{type}{Type of package to \code{update}.}
 
 \item{...}{Other arguments passed on to \code{\link[utils:install.packages]{utils::install.packages()}}.}
 }

--- a/man/install_github.Rd
+++ b/man/install_github.Rd
@@ -5,7 +5,11 @@
 \title{Attempts to install a package directly from GitHub.}
 \usage{
 install_github(repo, ref = "master", subdir = NULL,
-  auth_token = github_pat(), host = "api.github.com", ...)
+  auth_token = github_pat(), host = "api.github.com",
+  dependencies = NA, upgrade = TRUE, force = FALSE, quiet = FALSE,
+  build = TRUE, build_opts = c("--no-resave-data", "--no-manual",
+  "--no-build-vignettes"), repos = getOption("repos"),
+  type = getOption("pkgType"), ...)
 }
 \arguments{
 \item{repo}{Repository address in the format
@@ -27,6 +31,31 @@ the \code{GITHUB_PAT} environment variable.}
 
 \item{host}{GitHub API host to use. Override with your GitHub enterprise
 hostname, for example, \code{"github.hostname.com/api/v3"}.}
+
+\item{dependencies}{Which dependencies do you want to check?
+Can be a character vector (selecting from "Depends", "Imports",
+"LinkingTo", "Suggests", or "Enhances"), or a logical vector.
+
+\code{TRUE} is shorthand for "Depends", "Imports", "LinkingTo" and
+"Suggests". \code{NA} is shorthand for "Depends", "Imports" and "LinkingTo"
+and is the default. \code{FALSE} is shorthand for no dependencies (i.e.
+just check this package, not its dependencies).}
+
+\item{upgrade}{If \code{TRUE}, also upgrade any of out date dependencies.}
+
+\item{force}{Force installation, even if the remote state has not changed
+since the previous install.}
+
+\item{quiet}{If \code{TRUE}, suppress output.}
+
+\item{build}{If \code{TRUE} build the package before installing.}
+
+\item{build_opts}{Options to pass to \code{R CMD build}, only used when \code{build}
+is \code{TRUE}.}
+
+\item{repos}{A character vector giving repositories to use.}
+
+\item{type}{Type of package to \code{update}.}
 
 \item{...}{Other arguments passed on to \code{\link[utils:install.packages]{utils::install.packages()}}.}
 }

--- a/man/install_gitlab.Rd
+++ b/man/install_gitlab.Rd
@@ -5,7 +5,10 @@
 \title{Install a package from GitLab}
 \usage{
 install_gitlab(repo, auth_token = gitlab_pat(), host = "gitlab.com",
-  ...)
+  dependencies = NA, upgrade = TRUE, force = FALSE, quiet = FALSE,
+  build = TRUE, build_opts = c("--no-resave-data", "--no-manual",
+  "--no-build-vignettes"), repos = getOption("repos"),
+  type = getOption("pkgType"), ...)
 }
 \arguments{
 \item{repo}{Repository address in the format
@@ -19,6 +22,31 @@ the \code{GITHUB_PAT} environment variable.}
 
 \item{host}{GitLab API host to use. Override with your GitLab enterprise
 hostname, for example, \code{"gitlab.hostname.com"}.}
+
+\item{dependencies}{Which dependencies do you want to check?
+Can be a character vector (selecting from "Depends", "Imports",
+"LinkingTo", "Suggests", or "Enhances"), or a logical vector.
+
+\code{TRUE} is shorthand for "Depends", "Imports", "LinkingTo" and
+"Suggests". \code{NA} is shorthand for "Depends", "Imports" and "LinkingTo"
+and is the default. \code{FALSE} is shorthand for no dependencies (i.e.
+just check this package, not its dependencies).}
+
+\item{upgrade}{If \code{TRUE}, also upgrade any of out date dependencies.}
+
+\item{force}{Force installation, even if the remote state has not changed
+since the previous install.}
+
+\item{quiet}{If \code{TRUE}, suppress output.}
+
+\item{build}{If \code{TRUE} build the package before installing.}
+
+\item{build_opts}{Options to pass to \code{R CMD build}, only used when \code{build}
+is \code{TRUE}.}
+
+\item{repos}{A character vector giving repositories to use.}
+
+\item{type}{Type of package to \code{update}.}
 
 \item{...}{Other arguments passed on to \code{\link[utils:install.packages]{utils::install.packages()}}.}
 }

--- a/man/install_local.Rd
+++ b/man/install_local.Rd
@@ -4,13 +4,42 @@
 \alias{install_local}
 \title{Install a package from a local file}
 \usage{
-install_local(path, subdir = NULL, ...)
+install_local(path, subdir = NULL, dependencies = NA, upgrade = TRUE,
+  force = FALSE, quiet = FALSE, build = TRUE,
+  build_opts = c("--no-resave-data", "--no-manual",
+  "--no-build-vignettes"), repos = getOption("repos"),
+  type = getOption("pkgType"), ...)
 }
 \arguments{
 \item{path}{path to local directory, or compressed file (tar, zip, tar.gz
 tar.bz2, tgz2 or tbz)}
 
 \item{subdir}{subdirectory within url bundle that contains the R package.}
+
+\item{dependencies}{Which dependencies do you want to check?
+Can be a character vector (selecting from "Depends", "Imports",
+"LinkingTo", "Suggests", or "Enhances"), or a logical vector.
+
+\code{TRUE} is shorthand for "Depends", "Imports", "LinkingTo" and
+"Suggests". \code{NA} is shorthand for "Depends", "Imports" and "LinkingTo"
+and is the default. \code{FALSE} is shorthand for no dependencies (i.e.
+just check this package, not its dependencies).}
+
+\item{upgrade}{If \code{TRUE}, also upgrade any of out date dependencies.}
+
+\item{force}{Force installation, even if the remote state has not changed
+since the previous install.}
+
+\item{quiet}{If \code{TRUE}, suppress output.}
+
+\item{build}{If \code{TRUE} build the package before installing.}
+
+\item{build_opts}{Options to pass to \code{R CMD build}, only used when \code{build}
+is \code{TRUE}.}
+
+\item{repos}{A character vector giving repositories to use.}
+
+\item{type}{Type of package to \code{update}.}
 
 \item{...}{Other arguments passed on to \code{\link[utils:install.packages]{utils::install.packages()}}.}
 }

--- a/man/install_svn.Rd
+++ b/man/install_svn.Rd
@@ -4,8 +4,11 @@
 \alias{install_svn}
 \title{Install a package from a SVN repository}
 \usage{
-install_svn(url, subdir = NULL, args = character(0), ...,
-  revision = NULL)
+install_svn(url, subdir = NULL, args = character(0), revision = NULL,
+  dependencies = NA, upgrade = TRUE, force = FALSE, quiet = FALSE,
+  build = TRUE, build_opts = c("--no-resave-data", "--no-manual",
+  "--no-build-vignettes"), repos = getOption("repos"),
+  type = getOption("pkgType"), ...)
 }
 \arguments{
 \item{url}{Location of package. The url should point to a public or
@@ -17,9 +20,34 @@ package we are interested in installing.}
 \item{args}{A character vector providing extra options to pass on to
 \command{svn}.}
 
-\item{...}{Other arguments passed on to \code{\link[utils:install.packages]{utils::install.packages()}}.}
-
 \item{revision}{svn revision, if omitted updates to latest}
+
+\item{dependencies}{Which dependencies do you want to check?
+Can be a character vector (selecting from "Depends", "Imports",
+"LinkingTo", "Suggests", or "Enhances"), or a logical vector.
+
+\code{TRUE} is shorthand for "Depends", "Imports", "LinkingTo" and
+"Suggests". \code{NA} is shorthand for "Depends", "Imports" and "LinkingTo"
+and is the default. \code{FALSE} is shorthand for no dependencies (i.e.
+just check this package, not its dependencies).}
+
+\item{upgrade}{If \code{TRUE}, also upgrade any of out date dependencies.}
+
+\item{force}{Force installation, even if the remote state has not changed
+since the previous install.}
+
+\item{quiet}{If \code{TRUE}, suppress output.}
+
+\item{build}{If \code{TRUE} build the package before installing.}
+
+\item{build_opts}{Options to pass to \code{R CMD build}, only used when \code{build}
+is \code{TRUE}.}
+
+\item{repos}{A character vector giving repositories to use.}
+
+\item{type}{Type of package to \code{update}.}
+
+\item{...}{Other arguments passed on to \code{\link[utils:install.packages]{utils::install.packages()}}.}
 }
 \description{
 This function requires \command{svn} to be installed on your system in order to

--- a/man/install_url.Rd
+++ b/man/install_url.Rd
@@ -4,13 +4,42 @@
 \alias{install_url}
 \title{Install a package from a url}
 \usage{
-install_url(url, subdir = NULL, ...)
+install_url(url, subdir = NULL, dependencies = NA, upgrade = TRUE,
+  force = FALSE, quiet = FALSE, build = TRUE,
+  build_opts = c("--no-resave-data", "--no-manual",
+  "--no-build-vignettes"), repos = getOption("repos"),
+  type = getOption("pkgType"), ...)
 }
 \arguments{
 \item{url}{location of package on internet. The url should point to a
 zip file, a tar file or a bzipped/gzipped tar file.}
 
 \item{subdir}{subdirectory within url bundle that contains the R package.}
+
+\item{dependencies}{Which dependencies do you want to check?
+Can be a character vector (selecting from "Depends", "Imports",
+"LinkingTo", "Suggests", or "Enhances"), or a logical vector.
+
+\code{TRUE} is shorthand for "Depends", "Imports", "LinkingTo" and
+"Suggests". \code{NA} is shorthand for "Depends", "Imports" and "LinkingTo"
+and is the default. \code{FALSE} is shorthand for no dependencies (i.e.
+just check this package, not its dependencies).}
+
+\item{upgrade}{If \code{TRUE}, also upgrade any of out date dependencies.}
+
+\item{force}{Force installation, even if the remote state has not changed
+since the previous install.}
+
+\item{quiet}{If \code{TRUE}, suppress output.}
+
+\item{build}{If \code{TRUE} build the package before installing.}
+
+\item{build_opts}{Options to pass to \code{R CMD build}, only used when \code{build}
+is \code{TRUE}.}
+
+\item{repos}{A character vector giving repositories to use.}
+
+\item{type}{Type of package to \code{update}.}
 
 \item{...}{Other arguments passed on to \code{\link[utils:install.packages]{utils::install.packages()}}.}
 }

--- a/man/install_version.Rd
+++ b/man/install_version.Rd
@@ -4,7 +4,10 @@
 \alias{install_version}
 \title{Install specified version of a CRAN package.}
 \usage{
-install_version(package, version = NULL, repos = getOption("repos"),
+install_version(package, version = NULL, dependencies = NA,
+  upgrade = TRUE, force = FALSE, quiet = FALSE, build = TRUE,
+  build_opts = c("--no-resave-data", "--no-manual",
+  "--no-build-vignettes"), repos = getOption("repos"),
   type = getOption("pkgType"), ...)
 }
 \arguments{
@@ -14,6 +17,44 @@ install_version(package, version = NULL, repos = getOption("repos"),
 recent version of the package, this function simply calls
 \code{\link[utils:install.packages]{utils::install.packages()}}. Otherwise, it looks at the list of
 archived source tarballs and tries to install an older version instead.}
+
+\item{dependencies}{logical indicating whether to also install
+    uninstalled packages which these packages depend on/link
+    to/import/suggest (and so on recursively).  Not used if \code{repos
+    = NULL}.  Can also be a character vector, a subset of
+    \code{c("Depends", "Imports", "LinkingTo", "Suggests", "Enhances")}.
+
+    Only supported if \code{lib} is of length one (or missing),
+    so it is unambiguous where to install the dependent packages.  If
+    this is not the case it is ignored, with a warning.
+
+    The default, \code{NA}, means
+    \code{c("Depends", "Imports", "LinkingTo")}.
+
+    \code{TRUE} means to use
+    \code{c("Depends", "Imports", "LinkingTo", "Suggests")} for
+    \code{pkgs} and
+    \code{c("Depends", "Imports", "LinkingTo")} for added dependencies:
+    this installs all the packages needed to run \code{pkgs}, their
+    examples, tests and vignettes (if the package author specified them
+    correctly).
+
+    In all of these, \code{"LinkingTo"} is omitted for binary packages.
+  }
+
+\item{upgrade}{If \code{TRUE}, also upgrade any of out date dependencies.}
+
+\item{force}{Force installation, even if the remote state has not changed
+since the previous install.}
+
+\item{quiet}{
+    logical: if true, reduce the amount of output.
+  }
+
+\item{build}{If \code{TRUE} build the package before installing.}
+
+\item{build_opts}{Options to pass to \code{R CMD build}, only used when \code{build}
+is \code{TRUE}.}
 
 \item{repos}{
     character vector, the base URL(s) of the repositories

--- a/man/package_deps.Rd
+++ b/man/package_deps.Rd
@@ -15,8 +15,11 @@ local_package_deps(pkgdir = ".", dependencies = NA)
 dev_package_deps(pkgdir = ".", dependencies = NA,
   repos = getOption("repos"), type = getOption("pkgType"), ...)
 
-\method{update}{package_deps}(object, ..., quiet = FALSE,
-  upgrade = TRUE)
+\method{update}{package_deps}(object, dependencies = NA,
+  upgrade = TRUE, force = FALSE, quiet = FALSE, build = TRUE,
+  build_opts = c("--no-resave-data", "--no-manual",
+  "--no-build-vignettes"), repos = getOption("repos"),
+  type = getOption("pkgType"), ...)
 }
 \arguments{
 \item{packages}{A character vector of package names.}
@@ -40,9 +43,17 @@ just check this package, not its dependencies).}
 
 \item{object}{A \code{package_deps} object.}
 
+\item{upgrade}{If \code{TRUE}, also upgrade any of out date dependencies.}
+
+\item{force}{Force installation, even if the remote state has not changed
+since the previous install.}
+
 \item{quiet}{If \code{TRUE}, suppress output.}
 
-\item{upgrade}{If \code{TRUE}, also upgrade any of out date dependencies.}
+\item{build}{If \code{TRUE} build the package before installing.}
+
+\item{build_opts}{Options to pass to \code{R CMD build}, only used when \code{build}
+is \code{TRUE}.}
 }
 \value{
 A \code{data.frame} with columns:

--- a/man/update_packages.Rd
+++ b/man/update_packages.Rd
@@ -4,8 +4,11 @@
 \alias{update_packages}
 \title{Update packages that are missing or out-of-date.}
 \usage{
-update_packages(packages, dependencies = NA,
-  repos = getOption("repos"), type = getOption("pkgType"))
+update_packages(packages, dependencies = NA, upgrade = TRUE,
+  force = FALSE, quiet = FALSE, build = TRUE,
+  build_opts = c("--no-resave-data", "--no-manual",
+  "--no-build-vignettes"), repos = getOption("repos"),
+  type = getOption("pkgType"), ...)
 }
 \arguments{
 \item{packages}{Character vector of packages to update.}
@@ -19,9 +22,23 @@ Can be a character vector (selecting from "Depends", "Imports",
 and is the default. \code{FALSE} is shorthand for no dependencies (i.e.
 just check this package, not its dependencies).}
 
+\item{upgrade}{If \code{TRUE}, also upgrade any of out date dependencies.}
+
+\item{force}{Force installation, even if the remote state has not changed
+since the previous install.}
+
+\item{quiet}{If \code{TRUE}, suppress output.}
+
+\item{build}{If \code{TRUE} build the package before installing.}
+
+\item{build_opts}{Options to pass to \code{R CMD build}, only used when \code{build}
+is \code{TRUE}.}
+
 \item{repos}{A character vector giving repositories to use.}
 
 \item{type}{Type of package to \code{update}.}
+
+\item{...}{Other arguments passed on to \code{\link[utils:install.packages]{utils::install.packages()}}.}
 }
 \description{
 Works similarly to \code{\link[utils:install.packages]{utils::install.packages()}} but doesn't install packages

--- a/tests/testthat/test-install-remote.R
+++ b/tests/testthat/test-install-remote.R
@@ -29,7 +29,14 @@ test_that("package2remotes looks for the DESCRIPTION in .libPaths", {
   expect_equal(package2remote("noremotes", lib = lib)$sha, NA_character_)
 
   # This is not a real package, so we can't actually build it
-  install("noremotes", lib = lib, quiet = TRUE, build = FALSE)
+  install("noremotes", lib = lib, quiet = TRUE, build = FALSE,
+          dependencies = FALSE,
+          upgrade = FALSE,
+          force = FALSE,
+          build_opts = c("--no-resave-data", "--no-manual", "--no-build-vignettes"),
+          repos = getOption("repos"),
+          type = getOption("pkgType"))
+
   expect_equal(package2remote("noremotes", lib = lib)$sha, "1.0.0")
 
   # Load the namespace, as packageDescription looks in loaded namespaces


### PR DESCRIPTION
This should make things more clear what is available, all options should
be now exposed and documented other than those to `install.packages()`

Mainly to address the last bit of https://github.com/r-lib/remotes/issues/129#issuecomment-420636312

> Just a small note that upgrade isn't a documented parameter of remotes::install_github(), nor is it a documented parameter of install.packages() (which is where the documentation of install_github says the ... are passed).