### PR TITLE
Put RTools on the path when necessary

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,12 +26,14 @@ Suggests:
     covr,
     git2r (>= 0.23.0),
     mockery,
-    pkgbuild,
+    pkgbuild (>= 1.0.0.9000),
     pingr,
     testthat,
     withr
 Depends:
     R (>= 3.0.0)
+Remotes:
+    r-lib/pkgbuild
 RoxygenNote: 6.1.0
 SystemRequirements: Subversion for install_svn, git for install_git
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,9 @@
 
 # Development
 
+* `install_()*` functions now temporally put Rtools on the PATH when necessary,
+  as long as the pkgbuild package is installed.
+
 * `standardise_dep()` exported, for use in devtools.
 
 * Remotes can be forced to use only its internal code by setting the

--- a/R/install.R
+++ b/R/install.R
@@ -3,8 +3,12 @@ install <- function(pkgdir = ".", dependencies = NA, quiet = TRUE, build =
   TRUE, build_opts = c("--no-resave-data", "--no-manual", "--no-build-vignettes"), ..., repos =
   getOption("repos")) {
 
-  if (file.exists(file.path(pkgdir, "src")) && ! has_devel()) {
-    missing_devel_warning(pkgdir)
+  if (file.exists(file.path(pkgdir, "src"))) {
+    if (has_package("pkgbuild")) {
+      pkgbuild::local_build_tools(required = TRUE)
+    } else if (!has_devel()) {
+      missing_devel_warning(pkgdir)
+    }
   }
 
   ## Check for circular dependencies. We need to know about the root


### PR DESCRIPTION
This avoids users needing to manually add the RTools location to their
PATH; which is error prone as you then have to update it for newer
RTools versions and ensure the unix tools bundled with RTools don't
conflict with other tools on your PATH.

This will require a pkgbuild release, as `local_build_tools()` does not exist in the CRAN version.