### PR TITLE
Only install remotes that are in the stated CRAN dependencies

### DIFF
--- a/R/deps.R
+++ b/R/deps.R
@@ -134,14 +134,13 @@ dev_package_deps <- function(pkgdir = ".", dependencies = NA,
 }
 
 combine_deps <- function(cran_deps, remote_deps) {
-  deps <- rbind(cran_deps, remote_deps)
-
   # Only keep the remotes that are specified in the cran_deps
-  # Keep only the Non-CRAN remotes if there are duplicates as we want to install
-  # the development version rather than the CRAN version. The remotes will
-  # always be specified after the CRAN dependencies, so using fromLast will
-  # filter out the CRAN dependencies.
-  deps[!duplicated(deps$package, fromLast = TRUE), ]
+  remote_deps <- remote_deps[remote_deps$package %in% cran_deps$package, ]
+
+  # If there are remote deps remove the equivalent CRAN deps
+  cran_deps <- cran_deps[!(cran_deps$package %in% remote_deps$package), ]
+
+  rbind(cran_deps, remote_deps)
 }
 
 ## -2 = not installed, but available on CRAN

--- a/R/deps.R
+++ b/R/deps.R
@@ -134,6 +134,12 @@ dev_package_deps <- function(pkgdir = ".", dependencies = NA,
 }
 
 combine_deps <- function(cran_deps, remote_deps) {
+  # If there are no dependencies there will be no remote dependencies either,
+  # so just return them (and don't force the remote_deps promise)
+  if (nrow(cran_deps) == 0) {
+    return(cran_deps)
+  }
+
   # Only keep the remotes that are specified in the cran_deps
   remote_deps <- remote_deps[remote_deps$package %in% cran_deps$package, ]
 


### PR DESCRIPTION
If we filter the dependencies like this we will ensure only remote dependencies listed in the CRAN dependencies will be installed. By this point we have already included only CRAN dependencies requested, e.g. if they are in Suggests and `dependencies = NA` they won't be here.

I think it used to work like this and the reason we went to always installing remotes is some people don't put the remote package in one of the other fields. But I agree it is nice to not install a remote if it is only in Suggests (and you are not installing Suggests), so I am ok changing the behavior.

Fixes #167