### PR TITLE
Helpful message when build fails for long paths

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -104,19 +104,23 @@ safe_build_package <- function(pkgdir, build_opts, dest_path, quiet, use_pkgbuil
       cat(output$stdout, sep = "\n")
       cat("STDERR:\n")
       cat(output$stderr, sep = "\n")
-      if (sys_type() == "windows" &&
-          any(grepl("over-long path length", output$stderr))) {
-        message(
-          "\nIt seems that this package contains files with very long paths.\n",
-          "This is not supported on most Windows versions. Please contact the\n",
-          "package authors and tell them about this. See this GitHub issue\n",
-          "for more details: https://github.com/r-lib/remotes/issues/84\n")
-      }
+      msg_for_long_paths(output)
       stop(sprintf("Failed to `R CMD build` package, try `build = FALSE`."),
            call. = FALSE)
     }
 
     file.path(dest_path, sub("^[*] building[^[:alnum:]]+([[:alnum:]_.]+)[^[:alnum:]]+$", "\\1", output$stdout[length(output$stdout)]))
+  }
+}
+
+msg_for_long_paths <- function(output) {
+  if (sys_type() == "windows" &&
+      any(grepl("over-long path length", output$stderr))) {
+    message(
+      "\nIt seems that this package contains files with very long paths.\n",
+      "This is not supported on most Windows versions. Please contact the\n",
+      "package authors and tell them about this. See this GitHub issue\n",
+      "for more details: https://github.com/r-lib/remotes/issues/84\n")
   }
 }
 

--- a/R/install.R
+++ b/R/install.R
@@ -108,7 +108,7 @@ safe_build_package <- function(pkgdir, build_opts, dest_path, quiet, use_pkgbuil
           any(grepl("over-long path length", output$stderr))) {
         message(
           "\nIt seems that this package contains files with very long paths.\n",
-          "This is not supported on most Windows versions. Please contant the\n",
+          "This is not supported on most Windows versions. Please contact the\n",
           "package authors and tell them about this. See this GitHub issue\n",
           "for more details: https://github.com/r-lib/remotes/issues/84\n")
       }

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -39,7 +39,7 @@ test_that("safe_build_package fails appropriately without pkgbuild", {
   capture.output(
     expect_error(fixed = TRUE,
     safe_build_package(test_path("invalidpkg"), build_opts = opts , out, quiet = TRUE, use_pkgbuild = FALSE),
-    "Error running 'build' (status '1')"
+    "Failed to `R CMD build` package"
   ))
 })
 


### PR DESCRIPTION
On windows. Closes #84.

This is for the case when we call `R CMD build` directly. Otherwise this should be "fixed" in pkgbuild.