### PR TITLE
Warn if R.home() has space on windows, old R

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -1,6 +1,8 @@
 install <- function(pkgdir, dependencies, quiet, build, build_opts, upgrade,
                     repos, type, ...) {
 
+  warn_for_potential_errors()
+
   if (file.exists(file.path(pkgdir, "src"))) {
     if (has_package("pkgbuild")) {
       pkgbuild::local_build_tools(required = TRUE)

--- a/R/utils.R
+++ b/R/utils.R
@@ -388,3 +388,19 @@ format_str <- function(x, width = Inf, trim = TRUE, justify = "none", ...) {
   }
   x
 }
+
+warn_for_potential_errors <- function() {
+  if (sys_type() == "windows" && grepl(" ", R.home()) &&
+      getRversion() <= "3.4.2") {
+    warning(immediate. = TRUE,
+      "\n!!! Installation will probably fail!\n",
+      "This version of R has trouble with building and installing packages if\n",
+      "the R HOME directory (currently '", R.home(), "')\n",
+      "has space characters. Possible workarounds include:\n",
+      "- installing R to the C: drive,\n",
+      "- installing it into a path without a space, or\n",
+      "- creating a drive letter for R HOME via the `subst` windows command, and\n",
+      "  starting R from the new drive.\n",
+      "See also https://github.com/r-lib/remotes/issues/98\n")
+  }
+}


### PR DESCRIPTION
Closes #98.

Hopefully we won't have any false positives.

It looks like this:
```
> install_version("pkgconfig")
Downloading package from url: https://cloud.r-project.org/src/contrib/pkgconfig_2.0.2.tar.gz
Warning in warn_for_potential_errors() :
  
!!! Installation will probably fail!
This version of R has trouble with building and installing packages if
the R HOME directory (currently 'E:/Program Files/R/R-3.4.2')
has space characters. Possible workarounds include:
- installing R to the C: drive,
- installing it into a path without a space, or
- creating a drive letter for R HOME via the `subst` windows command, and
  starting R from the new drive.
See also https://github.com/r-lib/remotes/issues/98

Running "E:/Program Files/R/R-3.4.2/bin/x64/Rcmd.exe" build "C:\Users\Gabor\AppData\Local\Temp\RtmpeCW82i\remotes98c6abce2d\pkgconfig" --no-resave-data \
  --no-resave-data --no-manual --no-build-vignettes
'E:\Program' is not recognized as an internal or external command,
operable program or batch file.
Error in run(bin, args = real_cmdargs, stdout_line_callback = real_callback(stdout),  : 
  System command error
>
```