### PR TITLE
Add pkgdown site

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,5 @@
+^docs$
+^_pkgdown\.yml$
 ^.*\.Rproj$
 ^\.Rproj\.user$
 ^Makefile$

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ matrix:
   include:
     - r: release
       after_success: Rscript -e 'covr::codecov()'
+      deploy:
+        provider: script
+        script: Rscript -e 'pkgdown::deploy_site_github(verbose = TRUE)'
+        skip-cleanup: true
     - r: release
       env: R_REMOTES_STANDALONE=true
 


### PR DESCRIPTION
I created the key with `travis::use_travis_deploy(travis_repo = "r-lib/remotes")`, this should be all the rest we need for the site. Assuming this works we can switch it to remotes.r-lib.org.

Deploys don't happen from PRs, so we would have to merge this to see if it works.