### PR TITLE
Include the message in the response

### DIFF
--- a/R/install-github.R
+++ b/R/install-github.R
@@ -172,7 +172,8 @@ github_resolve_ref.github_pull <- function(x, params, ..., auth_token = NULL) {
   ## Just because libcurl might download the error page...
   if (methods::is(response, "error") || is.null(response$head)) {
     stop("Cannot find GitHub pull request ", params$username, "/",
-         params$repo, "#", x)
+         params$repo, "#", x, "\n",
+         response$message)
   }
 
   params$username <- response$head$user$login
@@ -191,7 +192,8 @@ github_resolve_ref.github_release <- function(x, params, ..., auth_token = NULL)
   )
 
   if (methods::is(response, "error") || !is.null(response$message)) {
-    stop("Cannot find repo ", params$username, "/", params$repo, ".")
+    stop("Cannot find repo ", params$username, "/", params$repo, ".", "\n",
+      response$message)
   }
 
   if (length(response) == 0L)


### PR DESCRIPTION
In both cases, an R condition object and the downloaded error page the
response will be in response$message, so we can use that
unconditionally.

This should expose the full error message explaining what has gone
wrong.