### PR TITLE
Fixes to ensure tests pass without internet

### DIFF
--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -9,7 +9,7 @@ skip_if_offline <- function(host = "httpbin.org", port = 80) {
   if (is.na(res)) skip("No internet connection")
 }
 
-skip_if_over_rate_limit <- function(by = 5) {
+skip_if_over_rate_limit <- function(by = 50) {
 
   tmp <- tempfile()
   download(

--- a/tests/testthat/test-install-bioc.R
+++ b/tests/testthat/test-install-bioc.R
@@ -20,6 +20,7 @@ test_that("install_bioc with git2r", {
 
   skip_without_package("git2r")
   skip_on_cran()
+  skip_if_offline()
 
   lib <- tempfile()
   on.exit(unlink(lib, recursive = TRUE), add = TRUE)
@@ -48,6 +49,7 @@ test_that("install_bioc with xgit", {
 
   skip_without_program("git")
   skip_on_cran()
+  skip_if_offline()
 
   lib <- tempfile()
   on.exit(unlink(lib, recursive = TRUE), add = TRUE)

--- a/tests/testthat/test-install-gitlab.R
+++ b/tests/testthat/test-install-gitlab.R
@@ -48,7 +48,7 @@ test_that("error if not username, warning if given as argument", {
 
 test_that("remote_download.gitlab_remote messages", {
 
-  mockery::stub(remote_download.gitlab_remote, "download_gitlab", TRUE)
+  mockery::stub(remote_download.gitlab_remote, "download", TRUE)
   expect_message(
     remote_download.gitlab_remote(
       remote("gitlab",


### PR DESCRIPTION
I also verified manually that all `skip_if_offline()` tests were paired
with `skip_on_cran()`, so all HTTP tests should not be run on CRAN

Fixes #187