### PR TITLE
Skip fetching submodules which exist in .Rbuildignore

### DIFF
--- a/R/submodule.R
+++ b/R/submodule.R
@@ -91,6 +91,9 @@ update_submodules <- function(source, quiet) {
   }
   info <- parse_submodules(file)
 
+  to_ignore <- in_r_build_ignore(info$path, file.path(source, ".Rbuildignore"))
+  info <- info[!to_ignore, ]
+
   for (i in seq_len(NROW(info))) {
     update_submodule(info$url[[i]], file.path(source, info$path[[i]]), info$branch[[i]], quiet)
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -9,6 +9,10 @@ viapply <- function(X, FUN, ..., USE.NAMES = TRUE) {
   vapply(X, FUN, integer(1L), ..., USE.NAMES = USE.NAMES)
 }
 
+vlapply <- function(X, FUN, ..., USE.NAMES = TRUE) {
+  vapply(X, FUN, logical(1L), ..., USE.NAMES = USE.NAMES)
+}
+
 rcmd <- function(cmd, args, path = R.home("bin"), quiet, fail_on_status = TRUE) {
   if (os_type() == "windows") {
     real_cmd <- file.path(path, "Rcmd.exe")
@@ -403,4 +407,35 @@ warn_for_potential_errors <- function() {
       "  starting R from the new drive.\n",
       "See also https://github.com/r-lib/remotes/issues/98\n")
   }
+}
+
+# Return all directories in the input paths
+directories <- function(paths) {
+  dirs <- unique(dirname(paths))
+  out <- dirs[dirs != "."]
+  while(length(dirs) > 0 && any(dirs != ".")) {
+    out <- unique(c(out, dirs[dirs != "."]))
+    dirs <- unique(dirname(dirs))
+  }
+  sort(out)
+}
+
+in_r_build_ignore <- function(paths, ignore_file) {
+  ignore <- ("tools" %:::% "get_exclude_patterns")()
+
+  if (file.exists(ignore_file)) {
+    ignore <- c(ignore, readLines(ignore_file, warn = FALSE))
+  }
+
+  matches_ignores <- function(x) {
+    any(vlapply(ignore, grepl, x, perl = TRUE, ignore.case = TRUE))
+  }
+
+  # We need to search for the paths as well as directories in the path, so
+  # `^foo$` matches `foo/bar`
+  should_ignore <- function(path) {
+    any(vlapply(c(path, directories(path)), matches_ignores))
+  }
+
+  vlapply(paths, should_ignore)
 }

--- a/tests/testthat/test-submodule.R
+++ b/tests/testthat/test-submodule.R
@@ -81,7 +81,7 @@ test_that("Can install a repo with a submodule", {
 
   dir <- tempfile()
   dir.create(dir)
-  on.exit(unlink(dir, recursive = TRUE))
+  on.exit(unlink(dir, recursive = TRUE, force = TRUE))
   writeLines("foo <- 1", file.path(dir, "foo.R"))
 
   in_dir(dir, {
@@ -122,11 +122,11 @@ test_that("Can install a repo with a submodule", {
   expect_false(dir.exists(file.path("submodule", "bar")))
 
   # Now remove the R directory so we can try installing the full package
-  unlink(file.path("submodule", "R"), recursive = TRUE)
+  unlink(file.path("submodule", "R"), recursive = TRUE, force = TRUE)
 
   # Install the package to a temporary library and verify it works
   lib <- tempfile()
-  on.exit(unlink(lib, recursive = TRUE), add = TRUE)
+  on.exit(unlink(lib, recursive = TRUE, force = TRUE), add = TRUE)
   dir.create(lib)
 
   install_local("submodule", lib = lib, quiet = TRUE)

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -144,3 +144,37 @@ test_that("windows untar, --force-local errors", {
   do(FALSE, function() 1L)
   do(FALSE, function() structure("blah", status = 1L))
 })
+
+test_that("directories works", {
+  expect_equal(directories("foo"), character())
+  expect_equal(directories("foo/bar"), "foo")
+  expect_equal(directories("foo/bar/baz"), c("foo", "foo/bar"))
+
+  expect_equal(directories(c("foo/bar", "foo/baz")), "foo")
+
+  expect_equal(directories(c("foo/bar/baz", "foo2/1", "foo3/bar/3")),
+               c("foo", "foo/bar", "foo2", "foo3", "foo3/bar"))
+})
+
+test_that("in_r_build_ignore works", {
+  tf <- tempfile()
+  on.exit(unlink(tf))
+  writeLines(
+    c("^foo$",
+      "^blah/xyz"
+    ), tf)
+
+  expect_equal(
+    unname(
+      in_r_build_ignore(c("foo/bar/baz", "R/test.R"), tf)
+    ),
+    c(TRUE, FALSE)
+  )
+
+  expect_equal(
+    unname(
+      in_r_build_ignore(c("foo", "blah", "blah/abc", "blah/xyz", "R/test.R"), tf)
+    ),
+    c(TRUE, FALSE, FALSE, TRUE, FALSE)
+  )
+})


### PR DESCRIPTION
This code is more complicated than it would otherwise need to be because
the way that `R CMD build` excludes files means that having `^foo$` in
your .Rbuildignore will ignore _all_ files in the foo/ directory.

So to determine if a given path should be ignored we need to match both
the path and it's directories against the patterns.

Fixes https://github.com/r-lib/remotes/issues/201