### PR TITLE
Remove reading of local .Rprofile

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 
 # devel
 
+* No longer include project specific .Rprofile code in the temporary .Rprofile when
+  `R_REMOTES_NO_ERRORS_FROM_WARNINGS=false` (the default).
+
 # remotes 2.0.0
 
 ## Breaking changes

--- a/R/utils.R
+++ b/R/utils.R
@@ -135,11 +135,6 @@ read_rprofile_user <- function() {
     return(readLines(f))
   }
 
-  f <- ".Rprofile"
-  if (file.exists(f)) {
-    return(readLines(f))
-  }
-
   f <- normalizePath("~/.Rprofile", mustWork = FALSE)
   if (file.exists(f)) {
     return(readLines(f))


### PR DESCRIPTION
Including the local .Rprofile causes issues with packrat.

Fixes https://github.com/r-lib/remotes/issues/214