### PR TITLE
Fix a bug in github_pat()

### DIFF
--- a/R/github.R
+++ b/R/github.R
@@ -70,7 +70,6 @@ github_commit <- function(username, repo, ref = "master",
 #' @noRd
 github_pat <- function(quiet = TRUE) {
   pat <- Sys.getenv("GITHUB_PAT")
-  if (identical(pat, "")) return(NULL)
 
   if (nzchar(pat)) {
     if (!quiet) {

--- a/tests/testthat/test-github.R
+++ b/tests/testthat/test-github.R
@@ -6,6 +6,12 @@ test_that("github_pat", {
 
   expect_equal(github_pat(), "badcafe")
   expect_message(github_pat(quiet = FALSE), "Using github PAT from envvar GITHUB_PAT")
+
+  withr::local_envvar(c(GITHUB_PAT=NA, CI=NA))
+  expect_equal(github_pat(), NULL)
+
+  withr::local_envvar(c(GITHUB_PAT=NA, CI="true"))
+  expect_true(nzchar(github_pat()))
 })
 
 test_that("github_commit", {

--- a/tests/testthat/test-github.R
+++ b/tests/testthat/test-github.R
@@ -12,7 +12,9 @@ test_that("github_pat", {
   })
   expect_equal(github_pat(), NULL)
 
-  withr::local_envvar(c(GITHUB_PAT=NA, CI="true"))
+  withr::with_envvar(c(GITHUB_PAT=NA, CI="true"), {
+    expect_true(nzchar(github_pat()))
+  })
   expect_true(nzchar(github_pat()))
 })
 

--- a/tests/testthat/test-github.R
+++ b/tests/testthat/test-github.R
@@ -7,7 +7,9 @@ test_that("github_pat", {
   expect_equal(github_pat(), "badcafe")
   expect_message(github_pat(quiet = FALSE), "Using github PAT from envvar GITHUB_PAT")
 
-  withr::local_envvar(c(GITHUB_PAT=NA, CI=NA))
+  withr::with_envvar(c(GITHUB_PAT=NA, CI=NA), {
+     expect_equal(github_pat(), NULL)
+  })
   expect_equal(github_pat(), NULL)
 
   withr::local_envvar(c(GITHUB_PAT=NA, CI="true"))


### PR DESCRIPTION
I guess #216 forgot to delete this early return so the bundled PAT will never be used.

https://github.com/r-lib/remotes/blob/2729d0e6cba9306bbfdfcde9d58133f87de20099/R/github.R#L73