### PR TITLE
Permit warnings if the envvar is unset and force suggests is false

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # remotes 2.0.1.9000 - Development
 
+* `install()` now avoids converting warnings to errors if
+  `R_REMOTES_NO_ERRORS_FROM_WARNINGS` is unset and
+  `_R_CHECK_FORCE_SUGGESTS_=false`. This avoids failures due to Suggested
+  packages potentially being missing.
+
 * `install_bitbucket()` now works properly with packages in subdirectories
   (#220)
 

--- a/R/install.R
+++ b/R/install.R
@@ -59,7 +59,7 @@ safe_install_packages <- function(...) {
 
     # Set options(warn = 2) for this process and child processes, so that
     # warnings from `install.packages()` are converted to errors.
-    if (Sys.getenv("R_REMOTES_NO_ERRORS_FROM_WARNINGS") != "true") {
+    if (should_error_for_warnings()) {
       with_options(list(warn = 2),
         with_rprofile_user("options(warn = 2)",
           i.p(...)
@@ -182,4 +182,13 @@ install_deps <- function(pkgdir = ".", dependencies = NA,
     build_opts = build_opts,
     ...
   )
+}
+
+should_error_for_warnings <- function() {
+
+  force_suggests <- Sys.getenv("_R_CHECK_FORCE_SUGGESTS_", "true")
+
+  no_errors <- Sys.getenv("R_REMOTES_NO_ERRORS_FROM_WARNINGS", !as.logical(force_suggests))
+
+  !as.logical(no_errors)
 }

--- a/inst/README.markdown
+++ b/inst/README.markdown
@@ -197,7 +197,12 @@ will allow successful installation of these packages.
   installation for warning messages. Warnings usually mean installation
   errors, so by default remotes stops for a warning. However, sometimes
   other warnings might happen, that could be ignored by setting this
-  environment variable.
+  environment variable. 
+
+* Setting `_R_CHECK_FORCE_SUGGESTS_=false` while
+  `R_REMOTES_NO_ERRORS_FROM_WARNINGS` is unset will also avoid stopping the
+  installation for error messages. This is done because a warning is generated
+  during installation when not all Suggested packages are not available.
 
 ## License
 

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -94,3 +94,26 @@ test_that("safe_build_package calls pkgbuild with appropriate arguments", {
       args = "--no-resave-data", quiet = TRUE)
   )
 })
+
+test_that("should_error_for_warnings works", {
+
+  # If both unset, should error -> TRUE
+  withr::with_envvar(c("R_REMOTES_NO_ERRORS_FROM_WARNINGS" = NA, "_R_CHECK_FORCE_SUGGESTS_" = NA),
+    expect_true(should_error_for_warnings())
+  )
+
+  # If no errors true, should error -> FALSE
+  withr::with_envvar(c("R_REMOTES_NO_ERRORS_FROM_WARNINGS" = "true", "_R_CHECK_FORCE_SUGGESTS_" = NA),
+    expect_false(should_error_for_warnings())
+  )
+
+  # If no errors unset, and force_suggests false, should error -> FALSE
+  withr::with_envvar(c("R_REMOTES_NO_ERRORS_FROM_WARNINGS" = NA, "_R_CHECK_FORCE_SUGGESTS_" = "false"),
+    expect_false(should_error_for_warnings())
+  )
+
+  # If no errors unset, and force_suggests true, should error -> TRUE
+  withr::with_envvar(c("R_REMOTES_NO_ERRORS_FROM_WARNINGS" = NA, "_R_CHECK_FORCE_SUGGESTS_" = "true"),
+    expect_true(should_error_for_warnings())
+  )
+})


### PR DESCRIPTION
A common case when warnings are emitted during installation is when a
Suggested package is not installed. So if
`R_REMOTES_NO_ERRORS_FROM_WARNINGS` is unset but
`_R_CHECK_FORCE_SUGGESTS_` we now turn off converting warnings to
errors.

Fixes #221