### PR TITLE
Remove DESCRIPTION metadata from install_version

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # remotes 2.0.1.9000 - Development
 
+* `install_version()` now removes metadata added as a byproduct of using
+  `install_url()` internally() (#224)
+
 * `install()` now avoids converting warnings to errors if
   `R_REMOTES_NO_ERRORS_FROM_WARNINGS` is unset and
   `_R_CHECK_FORCE_SUGGESTS_=false`. This avoids failures due to Suggested

--- a/R/install-remote.R
+++ b/R/install-remote.R
@@ -77,12 +77,28 @@ install_remotes <- function(remotes, ...) {
 
 # Add metadata
 add_metadata <- function(pkg_path, meta) {
-  path <- file.path(pkg_path, "DESCRIPTION")
-  desc <- read_dcf(path)
 
-  desc <- utils::modifyList(desc, meta)
+  # During installation, the DESCRIPTION file is read and an package.rds file
+  # created with most of the information from the DESCRIPTION file. Functions
+  # that read package metadata may use either the DESCRIPTION file or the
+  # package.rds file, therefore we attempt to modify both of them
+  source_desc <- file.path(pkg_path, "DESCRIPTION")
+  binary_desc <- file.path(pkg_path, "Meta", "package.rds")
+  if (file.exists(source_desc)) {
+    desc <- read_dcf(source_desc)
 
-  write_dcf(path, desc)
+    desc <- modifyList(desc, meta)
+
+    write_dcf(source_desc, desc)
+  }
+
+  if (file.exists(binary_desc)) {
+    pkg_desc <- base::readRDS(binary_desc)
+    desc <- as.list(pkg_desc$DESCRIPTION)
+    desc <- modifyList(desc, meta)
+    pkg_desc$DESCRIPTION <- stats::setNames(as.character(desc), names(desc))
+    base::saveRDS(pkg_desc, binary_desc)
+  }
 }
 
 # Modify the MD5 file - remove the line for DESCRIPTION

--- a/R/install-version.R
+++ b/R/install-version.R
@@ -30,7 +30,7 @@ install_version <- function(package, version = NULL,
                             ...) {
 
   url <- download_version_url(package, version, repos, type)
-  install_url(url,
+  res <- install_url(url,
               dependencies = dependencies,
               upgrade = upgrade,
               force = force,
@@ -40,6 +40,15 @@ install_version <- function(package, version = NULL,
               repos = repos,
               type = type,
               ...)
+
+  lib <- list(...)$lib
+
+  # Remove Metadata from installed package
+  add_metadata(
+    system.file(package = package, lib.loc = lib),
+    list(RemoteType = NULL, RemoteUrl = NULL, RemoteSubdir = NULL))
+
+  invisible(res)
 }
 
 package_find_repo <- function(package, repos) {

--- a/tests/testthat/test-install-version.R
+++ b/tests/testthat/test-install-version.R
@@ -19,9 +19,11 @@ test_that("install_version", {
   install_version("pkgconfig", "1.0.0", lib = lib, repos = repos, quiet = TRUE)
 
   expect_silent(packageDescription("pkgconfig", lib.loc = lib))
-  expect_equal(
-    packageDescription("pkgconfig", lib.loc = lib)$Version,
-    "1.0.0")
+  desc <- packageDescription("pkgconfig", lib.loc = lib)
+  expect_equal(desc$Version, "1.0.0")
+  expect_null(desc$RemoteType)
+  expect_null(desc$RemoteSubdir)
+  expect_null(desc$RemoteUrl)
 })
 
 test_that("package_find_repo() works correctly with multiple repos", {
@@ -108,7 +110,11 @@ test_that("install_version for archived packages", {
   if (length(repos) == 0) repos <- character()
   repos[repos == "@CRAN@"] <- "http://cran.rstudio.com"
 
+  lib <- tempfile()
+
   mockery::stub(install_version, "install_url", function(url, ...) url)
+  mockery::stub(install_version, "add_metadata", NULL)
+
   expect_match(fixed = TRUE,
     install_version("igraph0", type = "source", lib = lib, repos = repos),
     "src/contrib/Archive/igraph0/igraph0_0.5.7.tar.gz"


### PR DESCRIPTION
install_version calls install_url internally, so these packages were
being inadvertently installed as URL remote packages, which makes them
not update like normal packages.

Now we remove this extraneous metadata, so it is as if they were installed from
CRAN with `install.packages()` originally.

Fixes #224