### PR TITLE
Fix for install_deps(upgrade=FALSE) and remote packages

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # remotes 2.0.1.9000 - Development
 
+* `install_deps()` now installs un-installed remotes packages even when `upgrade = "never"` (@ankane, #227)
+
 * `install_version()` now removes metadata added as a byproduct of using
   `install_url()` internally() (#224)
 

--- a/R/deps.R
+++ b/R/deps.R
@@ -511,6 +511,7 @@ remote_deps <- function(pkg, ...) {
   available <- vapply(remote, function(x) remote_sha(x), character(1), USE.NAMES = FALSE)
   diff <- installed == available
   diff <- ifelse(!is.na(diff) & diff, CURRENT, BEHIND)
+  diff[is.na(installed)] <- UNINSTALLED
 
   res <- structure(
     data.frame(


### PR DESCRIPTION
Currently on master, `remotes::install_deps(upgrade=FALSE)` does nothing for a `DESCRIPTION` file like:

```
Imports: dbx
Remotes: github::ankane/dbx
```

This fixes it.