### PR TITLE
don't update submodules in install_local() (fixes #236)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@
 
 # remotes 2.0.2
 
+* `install_local()` now omits updating git submodules (@tnagler, #237)
+
 * `install_deps()` now installs un-installed remotes packages even when
   `upgrade = "never"` (@ankane, #227)
 

--- a/R/install-remote.R
+++ b/R/install-remote.R
@@ -52,7 +52,9 @@ install_remote <- function(remote,
   source <- source_pkg(bundle, subdir = remote$subdir)
   on.exit(unlink(source, recursive = TRUE), add = TRUE)
 
-  update_submodules(source, quiet)
+  if (!inherits(remote, "local_remote")) {
+    update_submodules(source, quiet)
+  }
 
   add_metadata(source, remote_metadata(remote, bundle, source, remote_sha))
 


### PR DESCRIPTION
Fixes #236. I did not include the reprex as a unit test because it takes several seconds to run. 