### PR TITLE
Remotes with missing package names are now unconditionally installed

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,7 @@
   If you rely on the proxy configuration of _wininet_, then you might
   want to set the `download.file.method` option, or use another way to
   set up proxies, see `?download.file`.
+* Remotes without package names are now unconditionally installed (#246).
 
 # remotes 2.0.2
 

--- a/R/install-version.R
+++ b/R/install-version.R
@@ -26,7 +26,7 @@ install_version <- function(package, version = NULL,
                             quiet = FALSE,
                             build = FALSE, build_opts = c("--no-resave-data", "--no-manual", "--no-build-vignettes"),
                             repos = getOption("repos"),
-                            type = getOption("pkgType"),
+                            type = "source",
                             ...) {
 
   url <- download_version_url(package, version, repos, type)

--- a/R/install.R
+++ b/R/install.R
@@ -11,11 +11,13 @@ install <- function(pkgdir, dependencies, quiet, build, build_opts, upgrade,
     }
   }
 
+  pkg_name <- load_pkg_description(pkgdir)$package
+
   ## Check for circular dependencies. We need to know about the root
   ## of the install process.
   if (is_root_install()) on.exit(exit_from_root_install(), add = TRUE)
   if (check_for_circular_dependencies(pkgdir, quiet)) {
-    return(invisible(NA_character_))
+    return(invisible(pkg_name))
   }
 
   install_deps(pkgdir, dependencies = dependencies, quiet = quiet,
@@ -37,7 +39,6 @@ install <- function(pkgdir, dependencies, quiet, build, build_opts, upgrade,
     ...
   )
 
-  pkg_name <- load_pkg_description(pkgdir)$package
   invisible(pkg_name)
 }
 


### PR DESCRIPTION
All URL remotes will have an NA package name, as there is no way to
determine it without downloading the full package.

Fixes #246