### PR TITLE
BUG FIX: Invalid R_LIBS* paths on Windows

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -44,7 +44,7 @@ install <- function(pkgdir, dependencies, quiet, build, build_opts, upgrade,
 
 safe_install_packages <- function(...) {
 
-  lib <- paste(.libPaths(), collapse = ":")
+  lib <- paste(.libPaths(), collapse = .Platform$path.sep)
 
   if (has_package("crancache") && has_package("callr")) {
     i.p <- "crancache" %::% "install_packages"


### PR DESCRIPTION
`safe_install_packages()` used a colon as a path separator also on Windows, resulting in invalid R_LIBS* values.

For example, with `startup::startup()` in `~/.Rprofile`, which checks for this, using `remotes::install_*()` would produce warnings about this:
```
Warning messages:
1: Environment variable 'R_LIBS_SITE' specifies a non-existing folder 'C:/Users/hb/Documents/R/win-library/3.5:C:/Program Files/R/R-3.5.1/library' (expands to 'C:\Users\hb\Documents\R\win-library\3.5:C:\Program Files\R\R-3.5.1\library') which R ignores and therefore are not used in .libPaths(). To create this folder, call dir.create("C:/Users/hb/Documents/R/win-library/3.5:C:/Program Files/R/R-3.5.1/library", recursive = TRUE) 
2: Environment variable 'R_LIBS_USER' specifies a non-existing folder 'C:/Users/hb/Documents/R/win-library/3.5:C:/Program Files/R/R-3.5.1/library' (expands to 'C:\Users\hb\Documents\R\win-library\3.5:C:\Program Files\R\R-3.5.1\library') which R ignores and therefore are not used in .libPaths(). To create this folder, call dir.create("C:/Users/hb/Documents/R/win-library/3.5:C:/Program Files/R/R-3.5.1/library", recursive = TRUE) 
```
