### PR TITLE
Custom headers in HTTP, use headers for basic auth

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,20 @@
   variable, to set the default for the `upgrade` argument. See README for
   details (@kevinushey, #240).
 
+* `install_*` functions perform basic HTTP authentication using HTTP
+  headers now. This fixes an issue with `install_bitbucket()` and private
+  repos (#255).
+
+* `install_*` functions now respect the `download.file.method` option,
+  if `download_file()` is used for HTTP.
+
+* `install_*` functions now use the _libcurl_ method, if the
+  `download.file.method` option is not set to a different one, and libcurl
+  is available. Before, the _wininet_ method was preferred on Windows.
+  If you rely on the proxy configuration of _wininet_, then you might
+  want to set the `download.file.method` option, or use another way to
+  set up proxies, see `?download.file`.
+
 # remotes 2.0.2
 
 * `install_deps()` now installs un-installed remotes packages even when

--- a/R/download.R
+++ b/R/download.R
@@ -41,7 +41,7 @@ base_download <- function(url, path, quiet, headers) {
     }, add = TRUE)
     ua <- orig(FALSE)
 
-    flathead <- paste0(names(headers), ": ", headers, "\r\n")
+    flathead <- paste0(names(headers), ": ", headers, collapse = "\r\n")
     agent <- paste0(ua, "\r\n", flathead)
     assign(
       "makeUserAgent",

--- a/R/download.R
+++ b/R/download.R
@@ -70,22 +70,28 @@ base_download <- function(url, path, quiet, headers) {
   path
 }
 
+has_curl <- function() isTRUE(unname(capabilities("libcurl")))
+
 download_method <- function() {
 
-  # R versions newer than 3.3.0 have correct default methods
-  if (compareVersion(get_r_version(), "3.3") == -1) {
+  user_option <- getOption("download.file.method")
 
-    if (os_type() == "windows") {
-      "wininet"
+  if (!is.null(user_option)) {
+    ## The user wants what the user wants
+    user_option
 
-    } else if (isTRUE(unname(capabilities("libcurl")))) {
-      "libcurl"
+  } else if (has_curl()) {
+    ## If we have libcurl, it is usually the best option
+    "libcurl"
 
-    } else {
-      "auto"
-    }
+  } else if (compareVersion(get_r_version(), "3.3") == -1 &&
+             os_type() == "windows") {
+    ## Before 3.3 we select wininet on Windows
+    "wininet"
 
   } else {
+    ## Otherwise this is probably hopeless, but let R select, and
+    ##  try something
     "auto"
   }
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -346,6 +346,63 @@ base64_decode <- function(x) {
   rawToChar(out)
 }
 
+basis64 <- charToRaw(paste(c(LETTERS, letters, 0:9, "+", "/"),
+                           collapse = ""))
+
+base64_encode <- function(x) {
+  if (is.character(x)) {
+    x <- charToRaw(x)
+  }
+
+  len <- length(x)
+  rlen <- floor((len + 2L) / 3L) * 4L
+  out <- raw(rlen)
+  ip <- op <- 1L
+  c <- integer(4)
+
+  while (len > 0L) {
+    c[[1]] <- as.integer(x[[ip]])
+    ip <- ip + 1L
+    if (len > 1L) {
+      c[[2]] <- as.integer(x[ip])
+      ip <- ip + 1L
+    } else {
+      c[[2]] <- 0L
+    }
+    out[op] <- basis64[1 + bitwShiftR(c[[1]], 2L)]
+    op <- op + 1L
+    out[op] <- basis64[1 + bitwOr(bitwShiftL(bitwAnd(c[[1]], 3L), 4L),
+                                  bitwShiftR(bitwAnd(c[[2]], 240L), 4L))]
+    op <- op + 1L
+
+    if (len > 2) {
+      c[[3]] <- as.integer(x[ip])
+      ip <- ip + 1L
+      out[op] <- basis64[1 + bitwOr(bitwShiftL(bitwAnd(c[[2]], 15L), 2L),
+                                    bitwShiftR(bitwAnd(c[[3]], 192L), 6L))]
+      op <- op + 1L
+      out[op] <- basis64[1 + bitwAnd(c[[3]], 63)]
+      op <- op + 1L
+
+    } else if (len == 2) {
+      out[op] <- basis64[1 + bitwShiftL(bitwAnd(c[[2]], 15L), 2L)]
+      op <- op + 1L
+      out[op] <- charToRaw("=")
+      op <- op + 1L
+
+    } else { ## len == 1
+      out[op] <- charToRaw("=")
+      op <- op + 1L
+      out[op] <- charToRaw("=")
+      op <- op + 1L
+
+    }
+    len <- len - 3L
+  }
+
+  rawToChar(out)
+}
+
 build_url <- function(host, ...) {
   download_url(do.call(file.path, as.list(c(host, ...))))
 }

--- a/README.md
+++ b/README.md
@@ -187,7 +187,33 @@ in R `Sys.setenv(R_REMOTES_STANDALONE="true")`) you can force remotes to
 operate in standalone mode and use only its internal R implementations. This
 will allow successful installation of these packages.
 
+### Options
+
+remotes uses the following stardard R options, see `?options` for their
+details:
+
+* `download.file.method` for the default download method. See
+  `?download.file`.
+
+* `pkgType` for the package type (source or binary, see manual) to install,
+  download or look up dependencies for.
+
+* `repos` for the locations of the user's standard CRAN(-like) repositoies.
+
+It also uses some remotes specific options:
+
+* `BioC_git` for the URL of the default BioConductor git mirror.
+
+* `unzip` for the path of the external `unzip` program.
+
 ### Environment variables
+
+* The `BITBUCKET_USER` and `BITBUCKET_PASSWORD` enrironment variables
+  are used for the default BitBucket  user name and password, in
+  `install_bitbucket()`
+
+* The `GITHUB_PAT` environment variable is used as the default GitHub
+  personal access token for all GitHub API queries.
 
 * The `R_REMOTES_UPGRADE` environment variable can be used to set a default
   preferred value for the `upgrade =` argument accepted by the various

--- a/tests/testthat/test-download.R
+++ b/tests/testthat/test-download.R
@@ -4,6 +4,7 @@ context("Download")
 test_that("download_method", {
 
   mockery::stub(download_method, "get_r_version", "3.3.0")
+  mockery::stub(download_method, "has_curl", FALSE)
   expect_equal(download_method(), "auto")
 
   mockery::stub(download_method, "get_r_version", "3.2.5")
@@ -12,12 +13,12 @@ test_that("download_method", {
 
   mockery::stub(download_method, "get_r_version", "3.2.5")
   mockery::stub(download_method, "os_type", "unix")
-  mockery::stub(download_method, "capabilities", c(libcurl = TRUE))
+  mockery::stub(download_method, "has_curl", TRUE)
   expect_equal(download_method(), "libcurl")
 
   mockery::stub(download_method, "get_r_version", "3.2.5")
   mockery::stub(download_method, "os_type", "unix")
-  mockery::stub(download_method, "capabilities", c(libcurl = FALSE))
+  mockery::stub(download_method, "has_curl", FALSE)
   expect_equal(download_method(), "auto")
 })
 
@@ -114,7 +115,7 @@ test_that("curl download with basic auth", {
   skip_if_offline()
   mockery::stub(download, "get_r_version", "3.0.0")
 
-  url <- "http://httpbin.org/basic-auth/ruser/rpass"
+  url <- "https://httpbin.org/basic-auth/ruser/rpass"
   tmp <- tempfile()
   on.exit(unlink(tmp), add = TRUE)
   download(url, path = tmp, quiet = TRUE,

--- a/tests/testthat/test-download.R
+++ b/tests/testthat/test-download.R
@@ -75,7 +75,7 @@ test_that("download with curl, basic auth", {
 
 test_that("base download with custom headers", {
   skip_if_offline()
-  url <- "https://httpbin.org/anything"
+  url <- "http://httpbin.org/anything"
   tmp <- tempfile()
   on.exit(unlink(tmp), add = TRUE)
   head <- c("X-Custom" = "Foobar")


### PR DESCRIPTION
BitBucket does not support Basic Auth via URL encoding,
apparently. So we use HTTP headers instead. This is somewhat
tricky, because base R  download.file()) does not allow
that directly. We need to shadow an internal function in utils,
and also make use of some bugs in curl and the internal
download methods, that let you specify multiple HTTP headers
via the User-Agent option.

This will also fix #255.

This PR also changes the default download method, slightly.
The default download method now respects the
`download.file.method` user option, if set.
Otherwise, if libcurl is supported, it will be
selected. (Before, wininet was preferred on Windows,
because it sets the proxies automatically, see #46.)
