### PR TITLE
Correct `auth_token` documentation for install_gitlab

### DIFF
--- a/R/install-gitlab.R
+++ b/R/install-gitlab.R
@@ -10,6 +10,11 @@
 #'   `username/repo[/subdir][@@ref]`.
 #' @param host GitLab API host to use. Override with your GitLab enterprise
 #'   hostname, for example, `"gitlab.hostname.com"`.
+#' @param auth_token To install from a private repo, generate a personal access
+#'   token (PAT) in \url{https://gitlab.com/profile/personal_access_tokens} and
+#'   supply to this argument. This is safer than using a password because you
+#'   can easily delete a PAT without affecting any others. Defaults to the
+#'   GITLAB_PAT environment variable.
 #' @inheritParams install_github
 #' @export
 #' @family package installation

--- a/man/install_gitlab.Rd
+++ b/man/install_gitlab.Rd
@@ -19,7 +19,7 @@ install_gitlab(repo, auth_token = gitlab_pat(), host = "gitlab.com",
 token (PAT) in \url{https://gitlab.com/profile/personal_access_tokens} and
 supply to this argument. This is safer than using a password because you
 can easily delete a PAT without affecting any others. Defaults to the
-GITHUB_LAB environment variable.}
+GITLAB_PAT environment variable.}
 
 \item{host}{GitLab API host to use. Override with your GitLab enterprise
 hostname, for example, \code{"gitlab.hostname.com"}.}

--- a/man/install_gitlab.Rd
+++ b/man/install_gitlab.Rd
@@ -15,11 +15,11 @@ install_gitlab(repo, auth_token = gitlab_pat(), host = "gitlab.com",
 \item{repo}{Repository address in the format
 \code{username/repo[/subdir][@ref]}.}
 
-\item{auth_token}{To install from a private repo, generate a personal
-access token (PAT) in \url{https://github.com/settings/applications} and
-supply to this argument. This is safer than using a password because
-you can easily delete a PAT without affecting any others. Defaults to
-the \code{GITHUB_PAT} environment variable.}
+\item{auth_token}{To install from a private repo, generate a personal access
+token (PAT) in \url{https://gitlab.com/profile/personal_access_tokens} and
+supply to this argument. This is safer than using a password because you
+can easily delete a PAT without affecting any others. Defaults to the
+GITHUB_LAB environment variable.}
 
 \item{host}{GitLab API host to use. Override with your GitLab enterprise
 hostname, for example, \code{"gitlab.hostname.com"}.}


### PR DESCRIPTION
Current documentation for `install_gitlab` inherits param `auth_token` from `install_github`. Added documentation for this param noting the correct URL to the personal access tokens (https://gitlab.com/profile/personal_access_tokens) and noting the environment variable should be "GITLAB_PAT".