### PR TITLE
remotes of remotes not given auth_token

### DIFF
--- a/R/install-gitlab.R
+++ b/R/install-gitlab.R
@@ -115,6 +115,10 @@ remote_package_name.gitlab_remote <- function(remote, ...) {
 
 #' @export
 remote_sha.gitlab_remote <- function(remote, ...) {
+   if (is.null(remote$auth_token)) {
+    auth_token <- list(...)
+    remote$auth_token <- auth_token$auth_token
+  }
   gitlab_commit(username = remote$username, repo = remote$repo,
     host = remote$host, ref = remote$ref, pat = remote$auth_token)
 }


### PR DESCRIPTION
When a package listed in Remotes of the description has a package listed in the Remotes, the auth_token wasn't transferring