### PR TITLE
only check setInternet2 for pre 3.3 R version

### DIFF
--- a/R/download.R
+++ b/R/download.R
@@ -136,8 +136,13 @@ download_method_secure <- function() {
     # known good methods
     TRUE
   } else if (identical(method, "internal")) {
-    # if internal then see if were using windows internal with inet2
-    identical(Sys.info()[["sysname"]], "Windows") && utils::setInternet2(NA)
+    # only done before R 3.3
+    if (utils::compareVersion(get_r_version(), "3.3") == -1) {
+      # if internal then see if were using windows internal with inet2
+      identical(Sys.info()[["sysname"]], "Windows") && utils::setInternet2(NA)
+    } else {
+      FALSE
+    }
   } else {
     # method with unknown properties (e.g. "lynx") or unresolved auto
     FALSE


### PR DESCRIPTION
this closes #250 

After some thoughts, in order to insure compatibility with previous R versions (DESCRIPTION says it R 3.0), the code is just encapsulated in a if clause checking the R version. 

Same as `download_method`

`setInternet2` was disabled in 3.3 and defunct in 3.4

This should work on all R version like this. 