### PR TITLE
Improve 404 messages for misspelled repo names/owners or lack of permissions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -29,6 +29,11 @@
   want to set the `download.file.method` option, or use another way to
   set up proxies, see `?download.file`.
 
+* `install_github()` now includes a more informative error message when the 
+  status code is 404, asking the user to check that they have spelled the
+  repo owner and repo correctly (included in the error message), and that 
+  they have the required permissions to access the repository.
+
 # remotes 2.0.2
 
 * `install_deps()` now installs un-installed remotes packages even when

--- a/R/github.R
+++ b/R/github.R
@@ -165,8 +165,28 @@ github_error <- function(res) {
           "Use `usethis::edit_r_environ()` and add the token as `GITHUB_PAT`."
         }
       )
-  }
+  } else if (identical(as.integer(res$status_code), 404L)) {
+    repo_information = re_match(res$url,"(repos)/(?P<owner>[^/]+)/(?P<repo>[^/]++)/")
+    pat_guidance <- sprintf(
+"Did you spell the repo owner (`%s`) and repo name (`%s`) correctly?
+  - If spelling is correct, check that you have the required permissions to access the repo.",
+        repo_information$owner,
+        repo_information$repo
+    )
 
+  }
+ if(identical(as.integer(res$status_code),404L)) {
+   msg <- sprintf(
+     "HTTP error %s.
+  %s
+
+  %s",
+
+     res$status_code,
+     error_details,
+     pat_guidance
+   )
+ } else {
   msg <- sprintf(
 "HTTP error %s.
   %s
@@ -183,6 +203,7 @@ github_error <- function(res) {
     format(ratelimit_reset, usetz = TRUE),
     pat_guidance
   )
+ }
 
   structure(list(message = msg, call = NULL), class = c("simpleError", "error", "condition"))
 }
@@ -190,6 +211,6 @@ github_error <- function(res) {
 
 #> Error: HTTP error 404.
 #>   Not Found
-#> 
+#>
 #>   Rate limit remaining: 4999
 #>   Rate limit reset at: 2018-10-10 19:43:52 UTC

--- a/R/github.R
+++ b/R/github.R
@@ -152,9 +152,9 @@ github_error <- function(res) {
 
   error_details <- fromJSON(rawToChar(res$content))$message
 
-  pat_guidance <- ""
+  guidance <- ""
   if (identical(as.integer(ratelimit_remaining), 0L)) {
-    pat_guidance <-
+    guidance <-
       sprintf(
 "To increase your GitHub API rate limit
   - Use `usethis::browse_github_pat()` to create a Personal Access Token.
@@ -166,14 +166,18 @@ github_error <- function(res) {
         }
       )
   } else if (identical(as.integer(res$status_code), 404L)) {
-    repo_information = re_match(res$url,"(repos)/(?P<owner>[^/]+)/(?P<repo>[^/]++)/")
-    pat_guidance <- sprintf(
-"Did you spell the repo owner (`%s`) and repo name (`%s`) correctly?
+    repo_information <- re_match(res$url, "(repos)/(?P<owner>[^/]+)/(?P<repo>[^/]++)/")
+    if(!is.na(repo_information$owner) && !is.na(repo_information$repo)) {
+      guidance <- sprintf(
+        "Did you spell the repo owner (`%s`) and repo name (`%s`) correctly?
   - If spelling is correct, check that you have the required permissions to access the repo.",
         repo_information$owner,
         repo_information$repo
-    )
-
+      )
+    } else {
+      guidance <- "Did you spell the repo owner and repo name correctly?
+  - If spelling is correct, check that you have the required permissions to access the repo."
+    }
   }
  if(identical(as.integer(res$status_code),404L)) {
    msg <- sprintf(
@@ -184,7 +188,7 @@ github_error <- function(res) {
 
      res$status_code,
      error_details,
-     pat_guidance
+     guidance
    )
  } else {
   msg <- sprintf(
@@ -201,7 +205,7 @@ github_error <- function(res) {
     ratelimit_remaining,
     ratelimit_limit,
     format(ratelimit_reset, usetz = TRUE),
-    pat_guidance
+    guidance
   )
  }
 

--- a/inst/install-github.R
+++ b/inst/install-github.R
@@ -1366,9 +1366,9 @@ github_error <- function(res) {
 
   error_details <- fromJSON(rawToChar(res$content))$message
 
-  pat_guidance <- ""
+  guidance <- ""
   if (identical(as.integer(ratelimit_remaining), 0L)) {
-    pat_guidance <-
+    guidance <-
       sprintf(
 "To increase your GitHub API rate limit
   - Use `usethis::browse_github_pat()` to create a Personal Access Token.
@@ -1380,14 +1380,18 @@ github_error <- function(res) {
         }
       )
   } else if (identical(as.integer(res$status_code), 404L)) {
-    repo_information = re_match(res$url,"(repos)/(?P<owner>[^/]+)/(?P<repo>[^/]++)/")
-    pat_guidance <- sprintf(
-"Did you spell the repo owner (`%s`) and repo name (`%s`) correctly?
+    repo_information <- re_match(res$url, "(repos)/(?P<owner>[^/]+)/(?P<repo>[^/]++)/")
+    if(!is.na(repo_information$owner) && !is.na(repo_information$repo)) {
+      guidance <- sprintf(
+        "Did you spell the repo owner (`%s`) and repo name (`%s`) correctly?
   - If spelling is correct, check that you have the required permissions to access the repo.",
         repo_information$owner,
         repo_information$repo
-    )
-
+      )
+    } else {
+      guidance <- "Did you spell the repo owner and repo name correctly?
+  - If spelling is correct, check that you have the required permissions to access the repo."
+    }
   }
  if(identical(as.integer(res$status_code),404L)) {
    msg <- sprintf(
@@ -1398,7 +1402,7 @@ github_error <- function(res) {
 
      res$status_code,
      error_details,
-     pat_guidance
+     guidance
    )
  } else {
   msg <- sprintf(
@@ -1415,7 +1419,7 @@ github_error <- function(res) {
     ratelimit_remaining,
     ratelimit_limit,
     format(ratelimit_reset, usetz = TRUE),
-    pat_guidance
+    guidance
   )
  }
 

--- a/install-github.R
+++ b/install-github.R
@@ -1366,9 +1366,9 @@ github_error <- function(res) {
 
   error_details <- fromJSON(rawToChar(res$content))$message
 
-  pat_guidance <- ""
+  guidance <- ""
   if (identical(as.integer(ratelimit_remaining), 0L)) {
-    pat_guidance <-
+    guidance <-
       sprintf(
 "To increase your GitHub API rate limit
   - Use `usethis::browse_github_pat()` to create a Personal Access Token.
@@ -1380,14 +1380,18 @@ github_error <- function(res) {
         }
       )
   } else if (identical(as.integer(res$status_code), 404L)) {
-    repo_information = re_match(res$url,"(repos)/(?P<owner>[^/]+)/(?P<repo>[^/]++)/")
-    pat_guidance <- sprintf(
-"Did you spell the repo owner (`%s`) and repo name (`%s`) correctly?
+    repo_information <- re_match(res$url, "(repos)/(?P<owner>[^/]+)/(?P<repo>[^/]++)/")
+    if(!is.na(repo_information$owner) && !is.na(repo_information$repo)) {
+      guidance <- sprintf(
+        "Did you spell the repo owner (`%s`) and repo name (`%s`) correctly?
   - If spelling is correct, check that you have the required permissions to access the repo.",
         repo_information$owner,
         repo_information$repo
-    )
-
+      )
+    } else {
+      guidance <- "Did you spell the repo owner and repo name correctly?
+  - If spelling is correct, check that you have the required permissions to access the repo."
+    }
   }
  if(identical(as.integer(res$status_code),404L)) {
    msg <- sprintf(
@@ -1398,7 +1402,7 @@ github_error <- function(res) {
 
      res$status_code,
      error_details,
-     pat_guidance
+     guidance
    )
  } else {
   msg <- sprintf(
@@ -1415,7 +1419,7 @@ github_error <- function(res) {
     ratelimit_remaining,
     ratelimit_limit,
     format(ratelimit_reset, usetz = TRUE),
-    pat_guidance
+    guidance
   )
  }
 


### PR DESCRIPTION
I have included code to return the repo name and repo owner in the error message when the status code is 404 (to check for misspellings), as well as remind the user to check if they have the required permissions to access the repo.

Fixes #271.
Fixes #276.