### PR TITLE
Add host argument to github_resolve_ref()

### DIFF
--- a/R/install-github.R
+++ b/R/install-github.R
@@ -77,7 +77,7 @@ github_remote <- function(repo, ref = "master", subdir = NULL,
                        host = "api.github.com", ...) {
 
   meta <- parse_git_repo(repo)
-  meta <- github_resolve_ref(meta$ref %||% ref, meta, auth_token)
+  meta <- github_resolve_ref(meta$ref %||% ref, meta, auth_token, host = host)
 
   remote("github",
     host = host,
@@ -162,11 +162,11 @@ github_resolve_ref.NULL <- function(x, params, ...) {
 }
 
 #' @export
-github_resolve_ref.github_pull <- function(x, params, ..., auth_token = github_pat()) {
+github_resolve_ref.github_pull <- function(x, params, ..., auth_token = github_pat(), host = "api.github.com") {
   # GET /repos/:user/:repo/pulls/:number
   path <- file.path("repos", params$username, params$repo, "pulls", x)
   response <- tryCatch(
-    github_GET(path, pat = auth_token),
+    github_GET(path, pat = auth_token, host = host),
     error = function(e) e
   )
 
@@ -184,11 +184,11 @@ github_resolve_ref.github_pull <- function(x, params, ..., auth_token = github_p
 
 # Retrieve the ref for the latest release
 #' @export
-github_resolve_ref.github_release <- function(x, params, ..., auth_token = github_pat()) {
+github_resolve_ref.github_release <- function(x, params, ..., auth_token = github_pat(), host = "api.github.com") {
   # GET /repos/:user/:repo/releases
   path <- paste("repos", params$username, params$repo, "releases", sep = "/")
   response <- tryCatch(
-    github_GET(path, pat = auth_token),
+    github_GET(path, pat = auth_token, host = host),
     error = function(e) e
   )
 


### PR DESCRIPTION
Fix #284 

Currently, `github_resolve_ref()` doesn't pass `host` to `github_GET()`, so if the ref contains a branch or a PR name, it fails for GitHub Enterprise.

This PR adds `host` argument to `github_resolve-ref()` and pass `host` to it.