### PR TITLE
Ignore newline after Additional_repositories (fix #251)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 
 # remotes dev
 
+* Fix parsing of Additional_Repositories which have a leading newline
+  (@tmelliott, #251).
+
 * Fix return type of `install_remote()` when there is a circular dependency (#225)
 
 * `remote_package_name.github_remote()` now works properly on Windows (#248)

--- a/R/deps.R
+++ b/R/deps.R
@@ -451,7 +451,7 @@ has_additional_repositories <- function(pkg) {
 
 parse_additional_repositories <- function(pkg) {
   if (has_additional_repositories(pkg)) {
-    strsplit(gsub("^[\n[:space:]]+", "", pkg[["additional_repositories"]]), "[,[:space:]]+")[[1]]
+    strsplit(gsub("^[[:space:]]*", "", pkg[["additional_repositories"]]), "[,[:space:]]+")[[1]]
   }
 }
 

--- a/R/deps.R
+++ b/R/deps.R
@@ -451,7 +451,7 @@ has_additional_repositories <- function(pkg) {
 
 parse_additional_repositories <- function(pkg) {
   if (has_additional_repositories(pkg)) {
-    strsplit(pkg[["additional_repositories"]], "[,[:space:]]+")[[1]]
+    strsplit(gsub("^[\n[:space:]]+", "", pkg[["additional_repositories"]]), "[,[:space:]]+")[[1]]
   }
 }
 

--- a/R/deps.R
+++ b/R/deps.R
@@ -451,7 +451,8 @@ has_additional_repositories <- function(pkg) {
 
 parse_additional_repositories <- function(pkg) {
   if (has_additional_repositories(pkg)) {
-    strsplit(gsub("^[[:space:]]*", "", pkg[["additional_repositories"]]), "[,[:space:]]+")[[1]]
+
+    strsplit(trim_ws(pkg[["additional_repositories"]]), "[,[:space:]]+")[[1]]
   }
 }
 

--- a/inst/install-github.R
+++ b/inst/install-github.R
@@ -421,13 +421,13 @@ combine_deps <- function(cran_deps, remote_deps) {
     return(cran_deps)
   }
 
-  # Only keep the remotes that are specified in the cran_deps
-  remote_deps <- remote_deps[remote_deps$package %in% cran_deps$package, ]
+  # Only keep the remotes that are specified in the cran_deps or are NA
+  remote_deps <- remote_deps[is.na(remote_deps$package) | remote_deps$package %in% cran_deps$package, ]
 
   # If there are remote deps remove the equivalent CRAN deps
   cran_deps <- cran_deps[!(cran_deps$package %in% remote_deps$package), ]
 
-  rbind(cran_deps, remote_deps)
+  rbind(remote_deps, cran_deps)
 }
 
 ## -2 = not installed, but available on CRAN
@@ -530,7 +530,7 @@ update.package_deps <- function(object,
 
   unavailable_on_cran <- object$diff == UNAVAILABLE & object$is_cran
 
-  unknown_remotes <- object$diff == UNAVAILABLE & !object$is_cran
+  unknown_remotes <- (object$diff == UNAVAILABLE | object$diff == UNINSTALLED) & !object$is_cran
 
   if (any(unavailable_on_cran) && !quiet) {
     message("Skipping ", sum(unavailable_on_cran), " packages not available: ",
@@ -572,7 +572,7 @@ update.package_deps <- function(object,
 
   behind <- is.na(object$installed) | object$diff < CURRENT
 
-  if (any(object$is_cran & behind)) {
+  if (any(object$is_cran & !unavailable_on_cran & behind)) {
     install_packages(object$package[object$is_cran & behind], repos = attr(object, "repos"),
       type = attr(object, "type"), dependencies = dependencies, quiet = quiet, ...)
   }
@@ -727,7 +727,8 @@ has_additional_repositories <- function(pkg) {
 
 parse_additional_repositories <- function(pkg) {
   if (has_additional_repositories(pkg)) {
-    strsplit(pkg[["additional_repositories"]], "[,[:space:]]+")[[1]]
+
+    strsplit(trim_ws(pkg[["additional_repositories"]]), "[,[:space:]]+")[[1]]
   }
 }
 
@@ -2566,6 +2567,11 @@ format.github_remote <- function(x, ...) {
 #'   `username/repo[/subdir][@@ref]`.
 #' @param host GitLab API host to use. Override with your GitLab enterprise
 #'   hostname, for example, `"gitlab.hostname.com"`.
+#' @param auth_token To install from a private repo, generate a personal access
+#'   token (PAT) in \url{https://gitlab.com/profile/personal_access_tokens} and
+#'   supply to this argument. This is safer than using a password because you
+#'   can easily delete a PAT without affecting any others. Defaults to the
+#'   GITLAB_PAT environment variable.
 #' @inheritParams install_github
 #' @export
 #' @family package installation
@@ -3337,7 +3343,7 @@ install_version <- function(package, version = NULL,
                             quiet = FALSE,
                             build = FALSE, build_opts = c("--no-resave-data", "--no-manual", "--no-build-vignettes"),
                             repos = getOption("repos"),
-                            type = getOption("pkgType"),
+                            type = "source",
                             ...) {
 
   url <- download_version_url(package, version, repos, type)
@@ -3454,11 +3460,13 @@ install <- function(pkgdir, dependencies, quiet, build, build_opts, upgrade,
     }
   }
 
+  pkg_name <- load_pkg_description(pkgdir)$package
+
   ## Check for circular dependencies. We need to know about the root
   ## of the install process.
   if (is_root_install()) on.exit(exit_from_root_install(), add = TRUE)
   if (check_for_circular_dependencies(pkgdir, quiet)) {
-    return(invisible(NA_character_))
+    return(invisible(pkg_name))
   }
 
   install_deps(pkgdir, dependencies = dependencies, quiet = quiet,
@@ -3480,7 +3488,6 @@ install <- function(pkgdir, dependencies, quiet, build, build_opts, upgrade,
     ...
   )
 
-  pkg_name <- load_pkg_description(pkgdir)$package
   invisible(pkg_name)
 }
 

--- a/install-github.R
+++ b/install-github.R
@@ -421,13 +421,13 @@ combine_deps <- function(cran_deps, remote_deps) {
     return(cran_deps)
   }
 
-  # Only keep the remotes that are specified in the cran_deps
-  remote_deps <- remote_deps[remote_deps$package %in% cran_deps$package, ]
+  # Only keep the remotes that are specified in the cran_deps or are NA
+  remote_deps <- remote_deps[is.na(remote_deps$package) | remote_deps$package %in% cran_deps$package, ]
 
   # If there are remote deps remove the equivalent CRAN deps
   cran_deps <- cran_deps[!(cran_deps$package %in% remote_deps$package), ]
 
-  rbind(cran_deps, remote_deps)
+  rbind(remote_deps, cran_deps)
 }
 
 ## -2 = not installed, but available on CRAN
@@ -530,7 +530,7 @@ update.package_deps <- function(object,
 
   unavailable_on_cran <- object$diff == UNAVAILABLE & object$is_cran
 
-  unknown_remotes <- object$diff == UNAVAILABLE & !object$is_cran
+  unknown_remotes <- (object$diff == UNAVAILABLE | object$diff == UNINSTALLED) & !object$is_cran
 
   if (any(unavailable_on_cran) && !quiet) {
     message("Skipping ", sum(unavailable_on_cran), " packages not available: ",
@@ -572,7 +572,7 @@ update.package_deps <- function(object,
 
   behind <- is.na(object$installed) | object$diff < CURRENT
 
-  if (any(object$is_cran & behind)) {
+  if (any(object$is_cran & !unavailable_on_cran & behind)) {
     install_packages(object$package[object$is_cran & behind], repos = attr(object, "repos"),
       type = attr(object, "type"), dependencies = dependencies, quiet = quiet, ...)
   }
@@ -727,7 +727,8 @@ has_additional_repositories <- function(pkg) {
 
 parse_additional_repositories <- function(pkg) {
   if (has_additional_repositories(pkg)) {
-    strsplit(pkg[["additional_repositories"]], "[,[:space:]]+")[[1]]
+
+    strsplit(trim_ws(pkg[["additional_repositories"]]), "[,[:space:]]+")[[1]]
   }
 }
 
@@ -2566,6 +2567,11 @@ format.github_remote <- function(x, ...) {
 #'   `username/repo[/subdir][@@ref]`.
 #' @param host GitLab API host to use. Override with your GitLab enterprise
 #'   hostname, for example, `"gitlab.hostname.com"`.
+#' @param auth_token To install from a private repo, generate a personal access
+#'   token (PAT) in \url{https://gitlab.com/profile/personal_access_tokens} and
+#'   supply to this argument. This is safer than using a password because you
+#'   can easily delete a PAT without affecting any others. Defaults to the
+#'   GITLAB_PAT environment variable.
 #' @inheritParams install_github
 #' @export
 #' @family package installation
@@ -3337,7 +3343,7 @@ install_version <- function(package, version = NULL,
                             quiet = FALSE,
                             build = FALSE, build_opts = c("--no-resave-data", "--no-manual", "--no-build-vignettes"),
                             repos = getOption("repos"),
-                            type = getOption("pkgType"),
+                            type = "source",
                             ...) {
 
   url <- download_version_url(package, version, repos, type)
@@ -3454,11 +3460,13 @@ install <- function(pkgdir, dependencies, quiet, build, build_opts, upgrade,
     }
   }
 
+  pkg_name <- load_pkg_description(pkgdir)$package
+
   ## Check for circular dependencies. We need to know about the root
   ## of the install process.
   if (is_root_install()) on.exit(exit_from_root_install(), add = TRUE)
   if (check_for_circular_dependencies(pkgdir, quiet)) {
-    return(invisible(NA_character_))
+    return(invisible(pkg_name))
   }
 
   install_deps(pkgdir, dependencies = dependencies, quiet = quiet,
@@ -3480,7 +3488,6 @@ install <- function(pkgdir, dependencies, quiet, build, build_opts, upgrade,
     ...
   )
 
-  pkg_name <- load_pkg_description(pkgdir)$package
   invisible(pkg_name)
 }
 

--- a/tests/testthat/test-deps.R
+++ b/tests/testthat/test-deps.R
@@ -178,6 +178,17 @@ test_that("Additional_repositories field", {
     parse_additional_repositories(pkg),
     c("http://packages.ropensci.org", "http://foo.bar.com")
   )
+
+  pkg <- list(
+    additional_repositories = 
+      "\n  http://packages.ropensci.org, \nhttp://foo.bar.com"
+  )
+
+  expect_equal(
+    parse_additional_repositories(pkg),
+    c("http://packages.ropensci.org", "http://foo.bar.com")
+  )
+
 })
 
 test_that("update.package_deps", {


### PR DESCRIPTION
New lines after `Additional_repositories` was resulting in a repository of `""`:
```
Additional_repositories:
    https://some.other.repo
```
parsed as
```r
remotes::parse_additional_repositories(pkg)
# c("", "https://some.other.repo")
```