### PR TITLE
Retain attributes when combining cran_deps + remote_deps

### DIFF
--- a/R/deps.R
+++ b/R/deps.R
@@ -150,8 +150,7 @@ combine_deps <- function(cran_deps, remote_deps) {
 
   # If there are remote deps remove the equivalent CRAN deps
   cran_deps <- cran_deps[!(cran_deps$package %in% remote_deps$package), ]
-
-  rbind(remote_deps, cran_deps)
+  rbind(cran_deps, remote_deps)
 }
 
 ## -2 = not installed, but available on CRAN

--- a/R/deps.R
+++ b/R/deps.R
@@ -150,6 +150,7 @@ combine_deps <- function(cran_deps, remote_deps) {
 
   # If there are remote deps remove the equivalent CRAN deps
   cran_deps <- cran_deps[!(cran_deps$package %in% remote_deps$package), ]
+
   rbind(cran_deps, remote_deps)
 }
 

--- a/tests/testthat/test-script.R
+++ b/tests/testthat/test-script.R
@@ -2,7 +2,6 @@
 context("install-github.R script")
 
 test_that("install-github.R script is up to date", {
-  skip("test has a path problem")
   root <- system.file(package = packageName())
   tmp <- test_temp_file(".R")
 

--- a/tests/testthat/test-script.R
+++ b/tests/testthat/test-script.R
@@ -2,6 +2,7 @@
 context("install-github.R script")
 
 test_that("install-github.R script is up to date", {
+  skip("test has a path problem")
   root <- system.file(package = packageName())
   tmp <- test_temp_file(".R")
 


### PR DESCRIPTION
`cran_deps` bears the `type` attribute

This fixes the problem I described in slack.

The order of arguments in `rbind()` affects the attributes of the resulting data frame.

``` r
a <- data.frame(a = 1)
attr(a, "yo") <- "hi"

b <- data.frame(a = 2)

attr(rbind(a, b), "yo")
#> [1] "hi"
attr(rbind(b, a), "yo")
#> NULL
```

<sup>Created on 2019-02-19 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1.9000)</sup>

I don't know why other people aren't seeing this, so perhaps there is more going on? But this fixes things for me.