### PR TITLE
Correct the url for generating github pat

### DIFF
--- a/R/install-github.R
+++ b/R/install-github.R
@@ -12,7 +12,7 @@
 #'   name, or a call to [github_pull()]. Defaults to `"master"`.
 #' @param subdir subdirectory within repo that contains the R package.
 #' @param auth_token To install from a private repo, generate a personal
-#'   access token (PAT) in <https://github.com/settings/applications> and
+#'   access token (PAT) in <https://github.com/settings/tokens> and
 #'   supply to this argument. This is safer than using a password because
 #'   you can easily delete a PAT without affecting any others. Defaults to
 #'   the `GITHUB_PAT` environment variable.
@@ -37,7 +37,7 @@
 #'   "mfrasca/r-logging/pkg"))
 #'
 #' # To install from a private repo, use auth_token with a token
-#' # from https://github.com/settings/applications. You only need the
+#' # from https://github.com/settings/tokens. You only need the
 #' # repo scope. Best practice is to save your PAT in env var called
 #' # GITHUB_PAT.
 #' install_github("hadley/private", auth_token = "abc")

--- a/man/install_github.Rd
+++ b/man/install_github.Rd
@@ -25,7 +25,7 @@ name, or a call to \code{\link[=github_pull]{github_pull()}}. Defaults to \code{
 \item{subdir}{subdirectory within repo that contains the R package.}
 
 \item{auth_token}{To install from a private repo, generate a personal
-access token (PAT) in \url{https://github.com/settings/applications} and
+access token (PAT) in \url{https://github.com/settings/tokens} and
 supply to this argument. This is safer than using a password because
 you can easily delete a PAT without affecting any others. Defaults to
 the \code{GITHUB_PAT} environment variable.}
@@ -82,7 +82,7 @@ install_github(c("hadley/httr@v0.4", "klutometis/roxygen#142",
   "mfrasca/r-logging/pkg"))
 
 # To install from a private repo, use auth_token with a token
-# from https://github.com/settings/applications. You only need the
+# from https://github.com/settings/tokens. You only need the
 # repo scope. Best practice is to save your PAT in env var called
 # GITHUB_PAT.
 install_github("hadley/private", auth_token = "abc")


### PR DESCRIPTION
The PR corrects the Github pat url from 

<https://github.com/settings/applications>

to 

<https://github.com/settings/tokens>.

The link was probably corrected in the earlier versions of `devtools` but didn't make it to the `remotes` package. For example, I can find the corrected version here: <https://devtools.r-lib.org/reference/install_github.html>. (This webpage is for `devtools` v1.13.6.9000, and the current v2.0.1 version doesn't have the `install_github()` function.)

By the way, after correcting the GitHub url, the instruction and example for installing a package from a private repo is

```R
#' # To install from a private repo, use auth_token with a token
#' # from https://github.com/settings/tokens. You only need the
#' # repo scope. Best practice is to save your PAT in env var called
#' # GITHUB_PAT.
#' install_github("hadley/private", auth_token = "abc")
```

Perhaps it would be helpful to be more detailed and split the example into two parts: (1) getting a token, and (2) save the token in one's "env var" as a `GITHUB_PAT`. Something like:

```R
#' # To install from a private repo, one needs to provide a personal 
#' # access token. Go to https://github.com/settings/tokens. Click 
#' # the "Generate new token" button. In the "New personal access 
#' # token" page (https://github.com/settings/tokens/new), select the
#' # repo scope, and click the "Generate token" button. Copy your 
#' # token, say "abc" (it'd be much longer), and use auth_token:
#' install_github("hadley/private", auth_token = "abc")
#'
#' # Best practice is to save your PAT as an environment variable 
#' # called GITHUB_PAT. Open your `.Renviron` file with 
#' # `usethis::edit_r_environ()`, save your token there as GITHUB_PAT="abc".
#' # Next time you can install from the private repo without specifying a token:
#' install_github("hadley/private")
```

HT: [BEST PRACTICE TO INSTALL A PACKAGE FROM A PRIVATE REPO PUBLISHED WED, DEC 6, 2017 BY MAURO LEPORE](https://maurolepore.netlify.com/2017/12/06/2017-12-06-best-prectice-for-installing-packages-from-private-repos/)