### PR TITLE
Support for GitLab subgroups

### DIFF
--- a/R/install-remote.R
+++ b/R/install-remote.R
@@ -49,7 +49,8 @@ install_remote <- function(remote,
   bundle <- remote_download(remote, quiet = quiet)
   on.exit(unlink(bundle), add = TRUE)
 
-  source <- source_pkg(bundle, subdir = remote$subdir)
+  if(inherits(remote, "gitlab_remote")) subdir <- NULL else subdir <- remote$subdir
+  source <- source_pkg(bundle, subdir = subdir)
   on.exit(unlink(source, recursive = TRUE), add = TRUE)
 
   update_submodules(source, quiet)


### PR DESCRIPTION
A quick and dirty prototype workaround to address issue #259.

As the `install_gitlab` seems to not support (yet) subdirectories, the workaround is based on the `subdir` variable. However in case a repo is inside a subgroup there is a mismatch – `subdir` corresponds to a repository, and `repo` to a subgroup (result of the general parsing rules in [parse_repo_spec](https://github.com/r-lib/remotes/blob/fb6682b6091412e75e313345ab54e96e82ed58b7/R/parse-git.R#L40)). How about fixing that mismatch with a new dedicated `parse_repo_gitlab` function?