### PR TITLE
Bioc version

### DIFF
--- a/R/bioc.R
+++ b/R/bioc.R
@@ -148,6 +148,17 @@ bioc_repos <- function(bioc_ver, r_ver) {
 bioc_install_repos <- function(r_ver = getRversion(),
                                bioc_ver = Sys.getenv("BIOCONDUCTOR_VERSION",
                                                      bioc_version(r_ver))) {
+
+  bioc_ver <- package_version(bioc_ver)
+  # check version compatibility
+  map <- bioc_version_map(r_ver)
+
+  if (!bioc_ver %in% map$Bioc[map$R == r_ver[, 1:2],]){
+    stop("Incompatible R and Bioconductor version, check BIOCONDUCTOR_VERSION",
+         call. = FALSE)
+  }
+
+  # get repos
   repos <- bioc_repos(bioc_ver, r_ver)
 
   repos

--- a/R/bioc.R
+++ b/R/bioc.R
@@ -1,6 +1,7 @@
 ## This is mostly from https://github.com/Bioconductor/BiocManager/blob/ba18f67fb886048b991c0f04a87894cf8c35b076/R/version.R
 
-bioc_version <- function(r_ver) {
+bioc_version <- function(r_ver = getRversion()) {
+  r_ver <- package_version(r_ver)
   map <- bioc_version_map(r_ver)
 
    if (r_ver[, 1:2] < min(map$R)){
@@ -21,7 +22,7 @@ bioc_version <- function(r_ver) {
 
 }
 
-bioc_version_map <- function(r_ver){
+bioc_version_map <- function(r_ver = getRversion()){
   # dput(BiocManager:::.version_map())
   map <- structure(list(Bioc = structure(list(c(1L, 6L), c(1L, 7L), c(1L,
                                                                       8L), c(1L, 9L), c(2L, 0L), c(2L, 1L), c(2L, 2L), 2:3, c(2L, 4L
@@ -99,6 +100,8 @@ get_online_bioc_version_map <- function(){
 }
 
 bioc_repos <- function(bioc_ver, r_ver) {
+
+  r_ver <- package_version(r_ver)
   bioc_ver <- as.package_version(bioc_ver)
 
   a <- NULL
@@ -149,6 +152,7 @@ bioc_install_repos <- function(r_ver = getRversion(),
                                bioc_ver = Sys.getenv("BIOCONDUCTOR_VERSION",
                                                      bioc_version(r_ver))) {
 
+  r_ver <- package_version(r_ver)
   bioc_ver <- package_version(bioc_ver)
   # check version compatibility
   map <- bioc_version_map(r_ver)
@@ -159,7 +163,7 @@ bioc_install_repos <- function(r_ver = getRversion(),
   }
 
   # get repos
-  repos <- bioc_repos(bioc_ver, r_ver)
+  repos <- bioc_repos(bioc_ver = bioc_ver, r_ver = r_ver)
 
   repos
 }


### PR DESCRIPTION
# Proposed changes

- Not in this PR, having an install_bioc() function that'd be more similar to the current install_cran() function, installing without git. Cf https://github.com/r-lib/remotes/issues/313

- Using a logic similar to BiocManager in bioc.R but with also the use of an environment variable that one could use to force the use of Bioconductor devel version.

- At the moment tests don't pass because of several factors
    - for some R versions it seems I'm not deducing the same Bioconductor version (but my code is in agreement with BiocManager)
    - on my computer there are default repositories for Bioconductor 3.6 and with the current code it interferes with the right Bioconductor version.

# Bioconductor support in remotes

- bioc.R and install-bioc.R are independent: install-bioc.R is only for the install_bioc() function, and doesn't use the other Bioconductor-related script, bioc.R.

- install_bioc() uses *git*. You can specify a mirror via the "BioC_git" option, but you cannot specify a Bioconductor version.

- As dependencies, Bioconductor packages are installed from the Bioconductor repository corresponding to the Bioconductor version determined via some logic. They are viewed as CRAN packages which apparently can lead to some issues cf https://github.com/r-lib/remotes/issues/275

# Bioconductor and R in general

- The installation of Bioconductor packages used to happen via a script sourced from an URL, which has been replaced with a proper CRAN package, BiocManager, available for R >= 3.5.0.

- Good read about the non-security of the old approach: https://www.jumpingrivers.com/blog/security-r-hacking-bioconductor/

- In R itself there's a legacy environment variable R_BIOC_VERSION https://github.com/wch/r-source/search?q=R_BIOC_VERSION&unscoped_q=R_BIOC_VERSION that actually isn't used to install Bioconductor packages for R >= 3.5.0.

- The mapping between R and Bioconductor version is stored in a YAML config file that can be parsed using code from BiocManager. 

- In particular, for some R versions there can be two valid Bioconductor versions at a time, one being the release version and the other being the devel version. A developer can prefer packages to be installed from any of those, so there needs to be a way to choose.
    - The BiocInstaller package had `BiocInstaller::isDevel()` that downloads the dev version of BiocInstaller ensuring all subsequent installations will be from Bioconductor devel version.
    - By default BiocManager uses the Bioconductor release version for the R version, if not available the devel version, if not available an out-of-date version (it's Bioconductor that's out-of-date, but still compatible with the R version), if not avaiable a future version.
    - `BiocManager::install()` has a version argument to specify the Bioconductor version. To switch to "devel" you'd write `BiocManager::install(version = "devel")`.
