### PR TITLE
url to lsr package on bitbucket fixed

### DIFF
--- a/R/install-bitbucket.R
+++ b/R/install-bitbucket.R
@@ -44,7 +44,7 @@
 #' @examples
 #' \dontrun{
 #' install_bitbucket("sulab/mygene.r@@default")
-#' install_bitbucket("dannavarro/lsr-package")
+#' install_bitbucket("djnavarro/lsr")
 #' }
 install_bitbucket <- function(repo, ref = "master", subdir = NULL,
                               auth_user = bitbucket_user(), password = bitbucket_password(),

--- a/man/install_bitbucket.Rd
+++ b/man/install_bitbucket.Rd
@@ -96,7 +96,7 @@ that it does \emph{not} set the system proxies automatically, see
 \examples{
 \dontrun{
 install_bitbucket("sulab/mygene.r@default")
-install_bitbucket("dannavarro/lsr-package")
+install_bitbucket("djnavarro/lsr")
 }
 }
 \seealso{


### PR DESCRIPTION
The location of the bitbucket copy of my lsr package has moved from "bitbucket.org/dannavarro/lsr-package" to "bitbucket.org/djnavarro/lsr". The link has been fixed in the install_bitbucket() function documentation. (I am also extremely new to making pull requests. My apologies if I've done something incorrectly here!)