### PR TITLE
updating so install robust to empty .gitmodules file

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 
 # remotes dev
 
+* `update_submodules()` now works with empty .gitmodules files (@jsilve24, #329).
+
 * remotes now understands the "standard" remote type, as produced by packages
   installed from CRAN using `pak` (#309)
 

--- a/R/submodule.R
+++ b/R/submodule.R
@@ -92,6 +92,9 @@ update_submodules <- function(source, quiet) {
   info <- parse_submodules(file)
 
   to_ignore <- in_r_build_ignore(info$path, file.path(source, ".Rbuildignore"))
+  if (!(length(info) > 0)) {
+    return()
+  }
   info <- info[!to_ignore, ]
 
   for (i in seq_len(NROW(info))) {


### PR DESCRIPTION
I ran into a small problem when trying to install a package with an empty .gitmodules file. I isolated the problem to a single line in the update_submodules function.

I have corrected the problem by just adding a condition that if the submodules file is empty, then the function should exit in exactly the same way as if the file had not been found. This makes the function robust to empty .gitmodules files. 


Hope this helps. 

Justin