### PR TITLE
Set RGL_USE_NULL to avoid rgl install errors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -38,6 +38,10 @@
   repo owner and repo correctly (included in the error message), and that 
   they have the required permissions to access the repository.
 
+* `install_*` fuctions (via the underlying private `install` function) now set
+  `RGL_USE_NULL="TRUE"` in order to avoid errors when running headless
+  and installing any package using `rgl` (@jefferis, ##333)
+  
 # remotes 2.0.2
 
 * `install_deps()` now installs un-installed remotes packages even when

--- a/R/install.R
+++ b/R/install.R
@@ -58,7 +58,7 @@ safe_install_packages <- function(...) {
     c(R_LIBS = lib,
       R_LIBS_USER = lib,
       R_LIBS_SITE = lib,
-      RGL_USE_NULL = TRUE),
+      RGL_USE_NULL = "TRUE"),
 
     # Set options(warn = 2) for this process and child processes, so that
     # warnings from `install.packages()` are converted to errors.

--- a/R/install.R
+++ b/R/install.R
@@ -57,7 +57,8 @@ safe_install_packages <- function(...) {
   with_envvar(
     c(R_LIBS = lib,
       R_LIBS_USER = lib,
-      R_LIBS_SITE = lib),
+      R_LIBS_SITE = lib,
+      RGL_USE_NULL = TRUE),
 
     # Set options(warn = 2) for this process and child processes, so that
     # warnings from `install.packages()` are converted to errors.


### PR DESCRIPTION
* fixes an issue when installing packages depending on rgl in a headless environment
  (e.g. remote server such as travis)
* closes #332