### PR TITLE
attach brew in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SRC := $(wildcard R/*R)
 all: inst/install-github.R install-github.R
 
 inst/install-github.R: inst/install-github.Rin $(SRC)
-	Rscript -e 'brew::brew("$<", "$@")'
+	Rscript -e 'library(brew);brew("$<", "$@")'
 
 install-github.R: inst/install-github.R
 	cp $< $@


### PR DESCRIPTION
Like I wrote in [#359](https://github.com/r-lib/remotes/pull/359#issuecomment-490475286) I was not able to run `make` successfully, because I got an error `Error: object 'brew' not found`.

<details>
<summary>Details</summary>

```bash

# First, what versions do I have?
$ make --version
GNU Make 4.2.1
Built for i686-pc-msys
Copyright (C) 1988-2016 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Daniel@Notebook-DP  ~/Documents/R/github/remotes (master)
$ R --version
R version 3.5.3 (2019-03-11) -- "Great Truth"
Copyright (C) 2019 The R Foundation for Statistical Computing
Platform: x86_64-w64-mingw32/x64 (64-bit)

R is free software and comes with ABSOLUTELY NO WARRANTY.
You are welcome to redistribute it under the terms of the
GNU General Public License versions 2 or 3.
For more information about these matters see
http://www.gnu.org/licenses/.

# make cannot find the brew package
Daniel@Notebook-DP  ~/Documents/R/github/remotes (master)
$ make
Rscript -e 'brew::brew("inst/install-github.Rin", "inst/install-github.R")'
Error: object 'brew' not found

# But brew is installed?!
Daniel@Notebook-DP  ~/Documents/R/github/remotes (master)
$ Rscript -e 'library(brew);brew(system.file("example1.brew",package="brew"),envir=new.env())'
Title: brew test
current time: 2019-05-09 12:39:38
value of foo: bar
 i is 1
from example2.brew, foo is: bar1
 i is 2
from example2.brew, foo is: bar12
 i is 3
from example2.brew, foo is: bar123
 i is 4
from example2.brew, foo is: bar1234
 i is 5
from example2.brew, foo is: bar12345
 i is 6
from example2.brew, foo is: bar123456
 i is 7
from example2.brew, foo is: bar1234567
 i is 8
from example2.brew, foo is: bar12345678
 i is 9
from example2.brew, foo is: bar123456789
 i is 10
from example2.brew, foo is: bar12345678910

```

</details>

It seems that the problems comes down to namespaceprefixing vs. attaching `brew`.

Anyway, I can run make successfully with this change.

```bash
Daniel@Notebook-DP  ~/Documents/R/github/remotes (master)
$ make
Rscript -e 'library(brew);brew("inst/install-github.Rin", "inst/install-github.R")'
cp inst/install-github.R install-github.R
```