### PR TITLE
trim trailing ws in versioned deps

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@
 
 # remotes (development version)
 
+* Fix bug in internal `parse_deps()` where test of valid comparison operators
+failed due to trailing whitespaces in DESCRIPTION fields (@LiNk-NY, #366)
+
 * `update.package_dependencies()` now uses the pkg_type for the cran remote
   rather than a global type attribute, fixing errors when this global attribute
   is lost (#291, #304).

--- a/R/package-deps.R
+++ b/R/package-deps.R
@@ -16,8 +16,8 @@ parse_deps <- function(string) {
   have_version <- grepl("\\(.*\\)", versions_str)
   versions_str[!have_version] <- NA
 
-  compare  <- trimws(sub(".*\\(\\s*(\\S+)\\s+.*\\s*\\)", "\\1", versions_str))
-  versions <- sub(".*\\(\\s*\\S+\\s+(\\S*)\\s*\\)", "\\1", versions_str)
+  compare  <- sub(".*\\(\\s*(\\S+)\\s+.*\\s*\\).*", "\\1", versions_str)
+  versions <- sub(".*\\(\\s*\\S+\\s+(\\S*)\\s*\\).*", "\\1", versions_str)
 
   # Check that non-NA comparison operators are valid
   compare_nna   <- compare[!is.na(compare)]

--- a/R/package-deps.R
+++ b/R/package-deps.R
@@ -16,7 +16,7 @@ parse_deps <- function(string) {
   have_version <- grepl("\\(.*\\)", versions_str)
   versions_str[!have_version] <- NA
 
-  compare  <- sub(".*\\(\\s*(\\S+)\\s+.*\\s*\\)", "\\1", versions_str)
+  compare  <- trimws(sub(".*\\(\\s*(\\S+)\\s+.*\\s*\\)", "\\1", versions_str))
   versions <- sub(".*\\(\\s*\\S+\\s+(\\S*)\\s*\\)", "\\1", versions_str)
 
   # Check that non-NA comparison operators are valid

--- a/inst/install-github.R
+++ b/inst/install-github.R
@@ -3838,7 +3838,7 @@ parse_deps <- function(string) {
   have_version <- grepl("\\(.*\\)", versions_str)
   versions_str[!have_version] <- NA
 
-  compare  <- sub(".*\\(\\s*(\\S+)\\s+.*\\s*\\)", "\\1", versions_str)
+  compare  <- trimws(sub(".*\\(\\s*(\\S+)\\s+.*\\s*\\)", "\\1", versions_str))
   versions <- sub(".*\\(\\s*\\S+\\s+(\\S*)\\s*\\)", "\\1", versions_str)
 
   # Check that non-NA comparison operators are valid

--- a/inst/install-github.R
+++ b/inst/install-github.R
@@ -3838,8 +3838,8 @@ parse_deps <- function(string) {
   have_version <- grepl("\\(.*\\)", versions_str)
   versions_str[!have_version] <- NA
 
-  compare  <- trimws(sub(".*\\(\\s*(\\S+)\\s+.*\\s*\\)", "\\1", versions_str))
-  versions <- sub(".*\\(\\s*\\S+\\s+(\\S*)\\s*\\)", "\\1", versions_str)
+  compare  <- sub(".*\\(\\s*(\\S+)\\s+.*\\s*\\).*", "\\1", versions_str)
+  versions <- sub(".*\\(\\s*\\S+\\s+(\\S*)\\s*\\).*", "\\1", versions_str)
 
   # Check that non-NA comparison operators are valid
   compare_nna   <- compare[!is.na(compare)]

--- a/tests/testthat/test-package-deps.R
+++ b/tests/testthat/test-package-deps.R
@@ -45,6 +45,17 @@ test_that("parse_deps", {
     )
   )
 
+  expect_equal(
+    parse_deps("package (>= 1.0.1)  , package2 (< 0.0.1 )  "),
+    structure(
+      list(
+        name = c("package", "package2"),
+        compare = c(">=", "<"),
+        version = c("1.0.1", "0.0.1")),
+      row.names = 1:2,
+      class = "data.frame"
+    )
+  )
 })
 
 


### PR DESCRIPTION
I'm getting issues with a space in the version comparison operator `<`. 
I have added a work-around. Preferably this would be handled in the regexp but
I wasn't able to work with it.
@gaborcsardi @jimhester 
Thanks,
Marcel