### PR TITLE
Forward type

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -181,6 +181,7 @@ install_deps <- function(pkgdir = ".", dependencies = NA,
     upgrade = upgrade,
     build = build,
     build_opts = build_opts,
+    type = type,
     ...
   )
 }


### PR DESCRIPTION
from `install_deps()` to `update()` .

Would it be better to set the corresponding option in the top-level function instead, to avoid passing `type` around?