### PR TITLE
Fix is.na() warning in combine_deps for R 3.4 and below

### DIFF
--- a/R/deps.R
+++ b/R/deps.R
@@ -144,7 +144,7 @@ combine_deps <- function(cran_deps, remote_deps) {
   }
 
   # Only keep the remotes that are specified in the cran_deps or are NA
-  remote_deps <- remote_deps[is.na(remote_deps$package) | remote_deps$package %in% cran_deps$package, ]
+  remote_deps <- remote_deps[is.null(remote_deps$package) | remote_deps$package %in% cran_deps$package, ]
 
   # If there are remote deps remove the equivalent CRAN deps
   cran_deps <- cran_deps[!(cran_deps$package %in% remote_deps$package), ]

--- a/inst/install-github.R
+++ b/inst/install-github.R
@@ -651,7 +651,7 @@ combine_deps <- function(cran_deps, remote_deps) {
   }
 
   # Only keep the remotes that are specified in the cran_deps or are NA
-  remote_deps <- remote_deps[is.na(remote_deps$package) | remote_deps$package %in% cran_deps$package, ]
+  remote_deps <- remote_deps[is.null(remote_deps$package) | remote_deps$package %in% cran_deps$package, ]
 
   # If there are remote deps remove the equivalent CRAN deps
   cran_deps <- cran_deps[!(cran_deps$package %in% remote_deps$package), ]

--- a/install-github.R
+++ b/install-github.R
@@ -651,7 +651,7 @@ combine_deps <- function(cran_deps, remote_deps) {
   }
 
   # Only keep the remotes that are specified in the cran_deps or are NA
-  remote_deps <- remote_deps[is.na(remote_deps$package) | remote_deps$package %in% cran_deps$package, ]
+  remote_deps <- remote_deps[is.null(remote_deps$package) | remote_deps$package %in% cran_deps$package, ]
 
   # If there are remote deps remove the equivalent CRAN deps
   cran_deps <- cran_deps[!(cran_deps$package %in% remote_deps$package), ]


### PR DESCRIPTION
Not an R user. So please make sure this is correct. e.g. `remote_deps$package` can't be `NA` so we also need a `NA` check, etc.

Fixes #362