### PR TITLE
Use proper platform separator for building

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -112,7 +112,7 @@ safe_build_package <- function(pkgdir, build_opts, build_manual, build_vignettes
   } else {
     # No pkgbuild, so we need to call R CMD build ourselves
 
-    lib <- paste(.libPaths(), collapse = ":")
+    lib <- paste(.libPaths(), collapse = .Platform$path.sep)
     env <- c(R_LIBS = lib,
       R_LIBS_USER = lib,
       R_LIBS_SITE = lib,

--- a/inst/install-github.R
+++ b/inst/install-github.R
@@ -3870,7 +3870,7 @@ safe_build_package <- function(pkgdir, build_opts, build_manual, build_vignettes
   } else {
     # No pkgbuild, so we need to call R CMD build ourselves
 
-    lib <- paste(.libPaths(), collapse = ":")
+    lib <- paste(.libPaths(), collapse = .Platform$path.sep)
     env <- c(R_LIBS = lib,
       R_LIBS_USER = lib,
       R_LIBS_SITE = lib,

--- a/install-github.R
+++ b/install-github.R
@@ -3870,7 +3870,7 @@ safe_build_package <- function(pkgdir, build_opts, build_manual, build_vignettes
   } else {
     # No pkgbuild, so we need to call R CMD build ourselves
 
-    lib <- paste(.libPaths(), collapse = ":")
+    lib <- paste(.libPaths(), collapse = .Platform$path.sep)
     env <- c(R_LIBS = lib,
       R_LIBS_USER = lib,
       R_LIBS_SITE = lib,


### PR DESCRIPTION
I noticed problems on AppVeyor when I set a nonstandard library with multiple entries. Pretty sure this is the cause, but didn't replicate yet.