### PR TITLE
Always follow redirects when downloading using external curl

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,9 @@
 
 ## Minor improvements and fixes
 
+* `download()` with the external curl download method now always uses `-L` to
+  follow redirects. (#350)
+
 * `update_packages()` now has a more informative error message when the update
   fails (#223, #232)
 

--- a/R/download.R
+++ b/R/download.R
@@ -107,6 +107,10 @@ base_download_curl <- function(url, path, quiet, headers) {
 
   extra <- getOption("download.file.extra")
 
+  # always add `-L`, so that curl follows redirects. GitHub in particular uses
+  # 302 redirects extensively, so without -L these requests fail.
+  extra <- c(extra, "-L")
+
   if (length(headers)) {
     qh <- shQuote(paste0(names(headers), ": ", headers))
     extra <- c(extra, paste("-H", qh))

--- a/inst/install-github.R
+++ b/inst/install-github.R
@@ -1362,6 +1362,10 @@ function(...) {
   
     extra <- getOption("download.file.extra")
   
+    # always add `-L`, so that curl follows redirects. GitHub in particular uses
+    # 302 redirects extensively, so without -L these requests fail.
+    extra <- c(extra, "-L")
+  
     if (length(headers)) {
       qh <- shQuote(paste0(names(headers), ": ", headers))
       extra <- c(extra, paste("-H", qh))

--- a/install-github.R
+++ b/install-github.R
@@ -1362,6 +1362,10 @@ function(...) {
   
     extra <- getOption("download.file.extra")
   
+    # always add `-L`, so that curl follows redirects. GitHub in particular uses
+    # 302 redirects extensively, so without -L these requests fail.
+    extra <- c(extra, "-L")
+  
     if (length(headers)) {
       qh <- shQuote(paste0(names(headers), ": ", headers))
       extra <- c(extra, paste("-H", qh))

--- a/tests/testthat/test-download.R
+++ b/tests/testthat/test-download.R
@@ -281,3 +281,20 @@ test_that("curl download with basic auth", {
   expect_true(resp$authenticated)
   expect_equal(resp$user, "ruser")
 })
+
+test_that("base curl download redirects", {
+  skip_on_cran()
+  skip_if_offline()
+  skip_without_program("curl")
+
+  url <- "http://httpbin.org/absolute-redirect/1"
+  tmp <- tempfile()
+  on.exit(unlink(tmp), add = TRUE)
+  with_options(
+    list(download.file.method = "curl"),
+         download(url, path = tmp, quiet = TRUE)
+  )
+  expect_true(file.exists(tmp))
+  resp <- json$parse(readLines(tmp))
+  expect_equal(resp$url, "https://httpbin.org/get")
+})


### PR DESCRIPTION
By default external curl does not follow redirects, but GitHub uses 302
redirects extensively, causing downloads to fail.

Fixes #350