### PR TITLE
Pass unnamed parameters to install_deps from install for more consistent behavior with unnamed parameters

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -23,7 +23,7 @@ install <- function(pkgdir, dependencies, quiet, build, build_opts, build_manual
   install_deps(pkgdir, dependencies = dependencies, quiet = quiet,
     build = build, build_opts = build_opts, build_manual = build_manual,
     build_vignettes = build_vignettes, upgrade = upgrade, repos = repos,
-    type = type)
+    type = type, ...)
 
   if (isTRUE(build)) {
     dir <- tempfile()


### PR DESCRIPTION
In the current code, unnamed parameters are not being passed and respected in install_deps while being respected in the safe_install_package itself. This leads to inconsistent behavior with unnamed parameters and how they are treated with regards to the package installation vs. the installation of the package dependencies.

I am not sure if the exclusion of the unnamed parameters being passed into install_deps was intentional. The documentation on the parameters does not seem to be explicit about this nuance so I suspect this was a bug.

For more context, here is our specific use case and why this change is important.
1) We are calling remotes through devtools
2) We are using devtools to install packages into app-specific library folders as part of our build and deployment process (our app includes R integration)
3) devtools and other build-related packages will be installed in a build machine-level library
4) We will need to have devtools target different library from the one it is loaded from to install app-specific R dependencies
5) This bug is preventing us from having that configurability (which it seems to offer from the documentation)

Happy to add more clarification if needed. Thank-you!