### PR TITLE
package2remote: improve error msg

### DIFF
--- a/R/install-remote.R
+++ b/R/install-remote.R
@@ -273,7 +273,7 @@ package2remote <- function(name, lib = .libPaths(), repos = getOption("repos"), 
       release = x$RemoteRelease,
       sha = x$RemoteSha,
       branch = x$RemoteBranch),
-    stop(sprintf("can't convert package with RemoteType '%s' to remote", x$RemoteType))
+    stop(sprintf("can't convert package '%s' with RemoteType '%s' to remote", x$Package, x$RemoteType))
   )
 }
 

--- a/inst/install-github.R
+++ b/inst/install-github.R
@@ -3563,7 +3563,7 @@ function(...) {
         release = x$RemoteRelease,
         sha = x$RemoteSha,
         branch = x$RemoteBranch),
-      stop(sprintf("can't convert package with RemoteType '%s' to remote", x$RemoteType))
+      stop(sprintf("can't convert package '%s' with RemoteType '%s' to remote", x$Package, x$RemoteType))
     )
   }
   

--- a/install-github.R
+++ b/install-github.R
@@ -3563,7 +3563,7 @@ function(...) {
         release = x$RemoteRelease,
         sha = x$RemoteSha,
         branch = x$RemoteBranch),
-      stop(sprintf("can't convert package with RemoteType '%s' to remote", x$RemoteType))
+      stop(sprintf("can't convert package '%s' with RemoteType '%s' to remote", x$Package, x$RemoteType))
     )
   }
   


### PR DESCRIPTION
This is a small fix which improves `package2remote`'s error message. In case it cannot convert the `RemoteType` it now also mentions which package is causing the error.