### PR TITLE
Fix install with submodules

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -54,6 +54,8 @@
 
 * git submodules now work if the submodule file is empty (@muschellij2, #234)
 
+* git submodules now work if the R package is stored in a subfolder (@pommedeterresautee, #233)
+
 * `install_gitlab()` no longer adds the access token twice to the request
   (@aornugent, #363).
 

--- a/R/install-remote.R
+++ b/R/install-remote.R
@@ -58,7 +58,7 @@ install_remote <- function(remote,
   source <- source_pkg(bundle, subdir = remote$subdir)
   on.exit(unlink(source, recursive = TRUE), add = TRUE)
 
-  update_submodules(source, quiet)
+  update_submodules(source, remote$subdir, quiet)
 
   add_metadata(source, remote_metadata(remote, bundle, source, remote_sha))
 

--- a/R/submodule.R
+++ b/R/submodule.R
@@ -84,10 +84,20 @@ update_submodule <- function(url, path, branch, quiet) {
   git(paste0(args, collapse = " "), quiet = quiet)
 }
 
-update_submodules <- function(source, quiet) {
+update_submodules <- function(source, subdir, quiet) {
   file <- file.path(source, ".gitmodules")
+
   if (!file.exists(file)) {
-    return()
+
+    if (!is.null(subdir)) {
+      nb_sub_folders <- lengths(strsplit(subdir, "/"))
+      source <- do.call(file.path, as.list(c(source, rep("..", nb_sub_folders))))
+    }
+
+    file <- file.path(source, ".gitmodules")
+    if (!file.exists(file)) {
+      return()
+    }
   }
   info <- parse_submodules(file)
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ If the R package is inside a subdirectory of the root directory,
 then give this subdirectory as well:
 
 ```r
-remotes::install_github("dmlc/xgboost/R-package")
+# build = FALSE because of some specificities of XGBoost package
+install_github("dmlc/xgboost/R-package", build = FALSE)
 ```
 
 To install a certain branch or commit or tag, append it to the

--- a/inst/install-github.R
+++ b/inst/install-github.R
@@ -3348,7 +3348,7 @@ function(...) {
     source <- source_pkg(bundle, subdir = remote$subdir)
     on.exit(unlink(source, recursive = TRUE), add = TRUE)
   
-    update_submodules(source, quiet)
+    update_submodules(source, remote$subdir, quiet)
   
     add_metadata(source, remote_metadata(remote, bundle, source, remote_sha))
   
@@ -4645,10 +4645,20 @@ function(...) {
     git(paste0(args, collapse = " "), quiet = quiet)
   }
   
-  update_submodules <- function(source, quiet) {
+  update_submodules <- function(source, subdir, quiet) {
     file <- file.path(source, ".gitmodules")
+  
     if (!file.exists(file)) {
-      return()
+  
+      if (!is.null(subdir)) {
+        nb_sub_folders <- lengths(strsplit(subdir, "/"))
+        source <- do.call(file.path, as.list(c(source, rep("..", nb_sub_folders))))
+      }
+  
+      file <- file.path(source, ".gitmodules")
+      if (!file.exists(file)) {
+        return()
+      }
     }
     info <- parse_submodules(file)
   

--- a/install-github.R
+++ b/install-github.R
@@ -3348,7 +3348,7 @@ function(...) {
     source <- source_pkg(bundle, subdir = remote$subdir)
     on.exit(unlink(source, recursive = TRUE), add = TRUE)
   
-    update_submodules(source, quiet)
+    update_submodules(source, remote$subdir, quiet)
   
     add_metadata(source, remote_metadata(remote, bundle, source, remote_sha))
   
@@ -4645,10 +4645,20 @@ function(...) {
     git(paste0(args, collapse = " "), quiet = quiet)
   }
   
-  update_submodules <- function(source, quiet) {
+  update_submodules <- function(source, subdir, quiet) {
     file <- file.path(source, ".gitmodules")
+  
     if (!file.exists(file)) {
-      return()
+  
+      if (!is.null(subdir)) {
+        nb_sub_folders <- lengths(strsplit(subdir, "/"))
+        source <- do.call(file.path, as.list(c(source, rep("..", nb_sub_folders))))
+      }
+  
+      file <- file.path(source, ".gitmodules")
+      if (!file.exists(file)) {
+        return()
+      }
     }
     info <- parse_submodules(file)
   

--- a/man/install_version.Rd
+++ b/man/install_version.Rd
@@ -21,9 +21,8 @@ archived source tarballs and tries to install an older version instead.}
 
 \item{dependencies}{logical indicating whether to also install
     uninstalled packages which these packages depend on/link
-    to/import/suggest (and so on recursively).
-    Not used if \code{repos = NULL}.
-    Can also be a character vector, a subset of
+    to/import/suggest (and so on recursively).  Not used if \code{repos
+    = NULL}.  Can also be a character vector, a subset of
     \code{c("Depends", "Imports", "LinkingTo", "Suggests", "Enhances")}.
 
     Only supported if \code{lib} is of length one (or missing),

--- a/tests/testthat/test-submodule.R
+++ b/tests/testthat/test-submodule.R
@@ -117,7 +117,7 @@ test_that("Can install a repo with a submodule", {
 
   writeLines("^bar$", build_ignore)
 
-  update_submodules("submodule", quiet = TRUE)
+  update_submodules("submodule", NULL, quiet = TRUE)
   expect_true(dir.exists(file.path("submodule", "R")))
   expect_false(dir.exists(file.path("submodule", "bar")))
 
@@ -154,6 +154,6 @@ test_that("Can update a submodule with an empty .gitmodules submodule", {
 
   writeLines("^bar$", build_ignore)
 
-  update_submodules("submodule", quiet = TRUE)
+  update_submodules("submodule", NULL, quiet = TRUE)
 
 })


### PR DESCRIPTION
Manage installation from a repo where there are submodules (+ update broken example from README)
Generalize proposed fix from #233 for R package stored in a sub sub ... folder.

Fix #233 and #407 
Related to https://github.com/dmlc/xgboost/issues/4710
