### PR TITLE
Spell check & modify package description

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,10 +11,10 @@ Authors@R: c(
     person("Dan", "Tenenbaum", role = "aut"),
     person("Mango Solutions", role = "cph")
     )
-Description: Download and install R packages stored in 'GitHub', 
-    'Bitbucket', or plain 'subversion' or 'git' repositories. This package
-    provides the 'install_*' functions in 'devtools'.
-    Indeed most of the code was copied over from 'devtools'.
+Description: Download and install R packages stored in 'GitHub', 'GitLab', 
+    'Bitbucket', 'Bioconductor', or plain 'subversion' or 'git' repositories. 
+    This package provides the 'install_*' functions in 'devtools'. Indeed most 
+    of the code was copied over from 'devtools'.
 License: GPL (>= 2)
 URL: https://github.com/r-lib/remotes#readme
 BugReports: https://github.com/r-lib/remotes/issues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,8 +11,8 @@ Authors@R: c(
     person("Dan", "Tenenbaum", role = "aut"),
     person("Mango Solutions", role = "cph")
     )
-Description: Download and install R packages stored in 'GitHub',
-    'BitBucket', or plain 'subversion' or 'git' repositories. This package
+Description: Download and install R packages stored in 'GitHub', 
+    'Bitbucket', or plain 'subversion' or 'git' repositories. This package
     provides the 'install_*' functions in 'devtools'.
     Indeed most of the code was copied over from 'devtools'.
 License: GPL (>= 2)

--- a/NEWS.md
+++ b/NEWS.md
@@ -127,7 +127,7 @@
   repo owner and repo correctly (included in the error message), and that 
   they have the required permissions to access the repository.
 
-* `install_*` fuctions (via the underlying private `install` function) now set
+* `install_*` functions (via the underlying private `install` function) now set
   `RGL_USE_NULL="TRUE"` in order to avoid errors when running headless
   and installing any package using `rgl` (@jefferis, ##333)
   
@@ -186,7 +186,7 @@
 ## New features
 
 * remotes now builds packages by default before installing them. This step
-  uses the pkgbuild package, if avilable. If not, it calls `R CMD build`
+  uses the pkgbuild package, if available. If not, it calls `R CMD build`
   directly.
 
 * New `install_dev()` to install the development version of a CRAN package,
@@ -207,7 +207,7 @@
 * `install_()` functions now pass arguments, including authentication
   information and upgrade down to dependencies (#53, #86, #87).
 
-* `install_()` functions allow the seclection of a subset of packages to
+* `install_()` functions allow the selection of a subset of packages to
   upgrade, in interactive mode, when `upgrade = "ask"`.
 
 * `install_git()` now supports passing credentials, when it is used with
@@ -224,7 +224,7 @@
 
 * remotes now uses the same SHA updating logic for remotes as devtools,
   including checking if the SHA of the remote has changed since the last
-  istallation. (#135)
+  installation. (#135)
 
 * `install_url()` can now install package binaries on windows
   (r-lib/devtools#1765)

--- a/NEWS.md
+++ b/NEWS.md
@@ -300,7 +300,7 @@
 
 * Check for circular dependencies while installing, #31
 
-* Updated BioConductor repo URLs for newer BioC versions
+* Updated Bioconductor repo URLs for newer BioC versions
 
 # remotes 1.0.0
 

--- a/R/bioc.R
+++ b/R/bioc.R
@@ -23,7 +23,7 @@ bioc_version <- function(r_ver = getRversion()) {
 #' can be set to force a Bioconductor version. If this is set, then the
 #' `r_ver` and `bioc_ver` arguments are ignored.
 #'
-#' `bioc_install_repos()` observes the `R_BIOC_MIRROR` enironment variable
+#' `bioc_install_repos()` observes the `R_BIOC_MIRROR` environment variable
 #' and also the `BioC_mirror` option, which can be set to the desired
 #' Bioconductor mirror. The option takes precedence if both are set. Its
 #' default value is `https://bioconductor.org`.
@@ -39,7 +39,7 @@ bioc_version <- function(r_ver = getRversion()) {
 #' @param r_ver R version to use. For `bioc_install_repos()` it is
 #'   ignored if `bioc_ver` is specified.
 #' @param bioc_ver Bioconductor version to use. Defaults to the default one
-#'   corresposding to `r_ver`.
+#'   corresponding to `r_ver`.
 #'
 #' @export
 #' @keywords internal

--- a/R/bioc.R
+++ b/R/bioc.R
@@ -16,7 +16,7 @@ bioc_version <- function(r_ver = getRversion()) {
 #' `bioc_version()` returns the Bioconductor version for the current or the
 #' specified R version.
 #'
-#' `bioc_install_repos()` deduces the URLs of the BioConductor repositories.
+#' `bioc_install_repos()` deduces the URLs of the Bioconductor repositories.
 #'
 #' @details
 #' Both functions observe the `R_BIOC_VERSION` environment variable, which
@@ -33,7 +33,7 @@ bioc_version <- function(r_ver = getRversion()) {
 #' object.
 #'
 #' `bioc_install_repos()` returns a named character vector of the URLs of
-#' the BioConductor repositories, appropriate for the current or the
+#' the Bioconductor repositories, appropriate for the current or the
 #' specified R version.
 #'
 #' @param r_ver R version to use. For `bioc_install_repos()` it is

--- a/R/install-bioc.R
+++ b/R/install-bioc.R
@@ -15,7 +15,7 @@
 #'   the release are \sQuote{devel},
 #'   \sQuote{release} (the default if none specified), or numeric release
 #'   numbers (e.g. \sQuote{3.3}).
-#' @param mirror The bioconductor git mirror to use
+#' @param mirror The Bioconductor git mirror to use
 #' @param ... Other arguments passed on to [utils::install.packages()].
 #' @inheritParams install_github
 #' @export

--- a/R/install-bitbucket.R
+++ b/R/install-bitbucket.R
@@ -1,5 +1,5 @@
 
-#' Install a package directly from bitbucket
+#' Install a package directly from Bitbucket
 #'
 #' This function is vectorised so you can install multiple packages in
 #' a single command.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 
 # remotes
 
-> Install R Packages from GitHub, Bitbucket, or other local or remote
-> repositories
+> Install R Packages from remote or local repositories, 
+> including GitHub, GitLab, Bitbucket, and Bioconductor
 
 [![Project Status: Active - The project has reached a stable, usable state and is being actively developed.](http://www.repostatus.org/badges/latest/active.svg)](http://www.repostatus.org/#active)
 [![Linux Build Status](https://travis-ci.org/r-lib/remotes.svg?branch=master)](https://travis-ci.org/r-lib/remotes)

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ details:
 * `pkgType` for the package type (source or binary, see manual) to install,
   download or look up dependencies for.
 
-* `repos` for the locations of the user's standard CRAN(-like) repositoies.
+* `repos` for the locations of the user's standard CRAN(-like) repositories.
 
 It also uses some remotes specific options:
 

--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ Indeed most of the code was copied over from `devtools`.
 ## Features
 
 * Installers:
-    * Install packages with their dependencies.
-    * Install from GitHub, GitLab, Bitbucket.
-	* Install from git and subversion repositories.
-	* Install from local files or URLs.
-	* Install the dependencies of a local package tree.
-	* Install specific package versions from CRAN.
+  * Install packages with their dependencies.
+  * Install from GitHub, GitLab, Bitbucket.
+  * Install from git and subversion repositories.
+  * Install from local files or URLs.
+  * Install the dependencies of a local package tree.
+  * Install specific package versions from CRAN.
 * Supports [Bioconductor](https://bioconductor.org/) packages.
 * Supports the `Remotes` field in `DESCRIPTION`. See more
   [here](https://github.com/r-lib/remotes/blob/master/vignettes/dependencies.Rmd).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # remotes
 
-> Install R Packages from GitHub, BitBucket, or other local or remote
+> Install R Packages from GitHub, Bitbucket, or other local or remote
 > repositories
 
 [![Project Status: Active - The project has reached a stable, usable state and is being actively developed.](http://www.repostatus.org/badges/latest/active.svg)](http://www.repostatus.org/#active)
@@ -12,7 +12,7 @@
 [![Coverage Status](https://img.shields.io/codecov/c/github/r-lib/remotes/master.svg)](https://codecov.io/github/r-lib/remotes?branch=master)
 
 Download and install R packages stored in GitHub,
-BitBucket, or plain subversion or git repositories. This package
+Bitbucket, or plain subversion or git repositories. This package
 is a lightweight replacement of the `install_*` functions in
 [`devtools`](https://github.com/r-lib/devtools).
 Indeed most of the code was copied over from `devtools`.
@@ -21,7 +21,7 @@ Indeed most of the code was copied over from `devtools`.
 
 * Installers:
     * Install packages with their dependencies.
-    * Install from GitHub, GitLab, BitBucket.
+    * Install from GitHub, GitLab, Bitbucket.
 	* Install from git and subversion repositories.
 	* Install from local files or URLs.
 	* Install the dependencies of a local package tree.
@@ -209,7 +209,7 @@ It also uses some remotes specific options:
 ### Environment variables
 
 * The `BITBUCKET_USER` and `BITBUCKET_PASSWORD` environment variables
-  are used for the default BitBucket  user name and password, in
+  are used for the default Bitbucket  user name and password, in
   `install_bitbucket()`
 
 * The `GITHUB_PAT` environment variable is used as the default GitHub

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 [![CRAN RStudio mirror downloads](https://cranlogs.r-pkg.org/badges/remotes)](https://www.r-pkg.org/pkg/remotes)
 [![Coverage Status](https://img.shields.io/codecov/c/github/r-lib/remotes/master.svg)](https://codecov.io/github/r-lib/remotes?branch=master)
 
-Download and install R packages stored in GitHub,
-Bitbucket, or plain subversion or git repositories. This package
+Download and install R packages stored in GitHub, GitLab, Bitbucket, 
+Bioconductor, or plain subversion or git repositories. This package
 is a lightweight replacement of the `install_*` functions in
 [`devtools`](https://github.com/r-lib/devtools).
 Indeed most of the code was copied over from `devtools`.

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Indeed most of the code was copied over from `devtools`.
   * Install the dependencies of a local package tree.
   * Install specific package versions from CRAN.
 * Supports [Bioconductor](https://bioconductor.org/) packages.
-* Supports the `Remotes` field in `DESCRIPTION`. See more
-  [here](https://github.com/r-lib/remotes/blob/master/vignettes/dependencies.Rmd).
+* Supports the `Remotes` field in `DESCRIPTION`. See more in the
+  [dependencies](https://github.com/r-lib/remotes/blob/master/vignettes/dependencies.Rmd) vignette.
 * Supports the `Additional_repositories` field in `DESCRIPTION`.
 * Can install itself from GitHub (see below).
 * Does not depend on other R packages.

--- a/inst/install-github.R
+++ b/inst/install-github.R
@@ -2133,7 +2133,7 @@ function(...) {
   
   # Contents of R/install-bitbucket.R
   
-  #' Install a package directly from bitbucket
+  #' Install a package directly from Bitbucket
   #'
   #' This function is vectorised so you can install multiple packages in
   #' a single command.

--- a/inst/install-github.R
+++ b/inst/install-github.R
@@ -323,7 +323,7 @@ function(...) {
   #' `bioc_version()` returns the Bioconductor version for the current or the
   #' specified R version.
   #'
-  #' `bioc_install_repos()` deduces the URLs of the BioConductor repositories.
+  #' `bioc_install_repos()` deduces the URLs of the Bioconductor repositories.
   #'
   #' @details
   #' Both functions observe the `R_BIOC_VERSION` environment variable, which
@@ -340,7 +340,7 @@ function(...) {
   #' object.
   #'
   #' `bioc_install_repos()` returns a named character vector of the URLs of
-  #' the BioConductor repositories, appropriate for the current or the
+  #' the Bioconductor repositories, appropriate for the current or the
   #' specified R version.
   #'
   #' @param r_ver R version to use. For `bioc_install_repos()` it is
@@ -1847,7 +1847,7 @@ function(...) {
   #'   the release are \sQuote{devel},
   #'   \sQuote{release} (the default if none specified), or numeric release
   #'   numbers (e.g. \sQuote{3.3}).
-  #' @param mirror The bioconductor git mirror to use
+  #' @param mirror The Bioconductor git mirror to use
   #' @param ... Other arguments passed on to [utils::install.packages()].
   #' @inheritParams install_github
   #' @export

--- a/inst/install-github.R
+++ b/inst/install-github.R
@@ -330,7 +330,7 @@ function(...) {
   #' can be set to force a Bioconductor version. If this is set, then the
   #' `r_ver` and `bioc_ver` arguments are ignored.
   #'
-  #' `bioc_install_repos()` observes the `R_BIOC_MIRROR` enironment variable
+  #' `bioc_install_repos()` observes the `R_BIOC_MIRROR` environment variable
   #' and also the `BioC_mirror` option, which can be set to the desired
   #' Bioconductor mirror. The option takes precedence if both are set. Its
   #' default value is `https://bioconductor.org`.
@@ -346,7 +346,7 @@ function(...) {
   #' @param r_ver R version to use. For `bioc_install_repos()` it is
   #'   ignored if `bioc_ver` is specified.
   #' @param bioc_ver Bioconductor version to use. Defaults to the default one
-  #'   corresposding to `r_ver`.
+  #'   corresponding to `r_ver`.
   #'
   #' @export
   #' @keywords internal

--- a/install-github.R
+++ b/install-github.R
@@ -2133,7 +2133,7 @@ function(...) {
   
   # Contents of R/install-bitbucket.R
   
-  #' Install a package directly from bitbucket
+  #' Install a package directly from Bitbucket
   #'
   #' This function is vectorised so you can install multiple packages in
   #' a single command.

--- a/install-github.R
+++ b/install-github.R
@@ -323,7 +323,7 @@ function(...) {
   #' `bioc_version()` returns the Bioconductor version for the current or the
   #' specified R version.
   #'
-  #' `bioc_install_repos()` deduces the URLs of the BioConductor repositories.
+  #' `bioc_install_repos()` deduces the URLs of the Bioconductor repositories.
   #'
   #' @details
   #' Both functions observe the `R_BIOC_VERSION` environment variable, which
@@ -340,7 +340,7 @@ function(...) {
   #' object.
   #'
   #' `bioc_install_repos()` returns a named character vector of the URLs of
-  #' the BioConductor repositories, appropriate for the current or the
+  #' the Bioconductor repositories, appropriate for the current or the
   #' specified R version.
   #'
   #' @param r_ver R version to use. For `bioc_install_repos()` it is
@@ -1847,7 +1847,7 @@ function(...) {
   #'   the release are \sQuote{devel},
   #'   \sQuote{release} (the default if none specified), or numeric release
   #'   numbers (e.g. \sQuote{3.3}).
-  #' @param mirror The bioconductor git mirror to use
+  #' @param mirror The Bioconductor git mirror to use
   #' @param ... Other arguments passed on to [utils::install.packages()].
   #' @inheritParams install_github
   #' @export

--- a/install-github.R
+++ b/install-github.R
@@ -330,7 +330,7 @@ function(...) {
   #' can be set to force a Bioconductor version. If this is set, then the
   #' `r_ver` and `bioc_ver` arguments are ignored.
   #'
-  #' `bioc_install_repos()` observes the `R_BIOC_MIRROR` enironment variable
+  #' `bioc_install_repos()` observes the `R_BIOC_MIRROR` environment variable
   #' and also the `BioC_mirror` option, which can be set to the desired
   #' Bioconductor mirror. The option takes precedence if both are set. Its
   #' default value is `https://bioconductor.org`.
@@ -346,7 +346,7 @@ function(...) {
   #' @param r_ver R version to use. For `bioc_install_repos()` it is
   #'   ignored if `bioc_ver` is specified.
   #' @param bioc_ver Bioconductor version to use. Defaults to the default one
-  #'   corresposding to `r_ver`.
+  #'   corresponding to `r_ver`.
   #'
   #' @export
   #' @keywords internal

--- a/man/bioc_install_repos.Rd
+++ b/man/bioc_install_repos.Rd
@@ -15,7 +15,7 @@ bioc_install_repos(r_ver = getRversion(),
 ignored if \code{bioc_ver} is specified.}
 
 \item{bioc_ver}{Bioconductor version to use. Defaults to the default one
-corresposding to \code{r_ver}.}
+corresponding to \code{r_ver}.}
 }
 \value{
 \code{bioc_version()} returns a Bioconductor version, a \code{package_version}
@@ -36,7 +36,7 @@ Both functions observe the \code{R_BIOC_VERSION} environment variable, which
 can be set to force a Bioconductor version. If this is set, then the
 \code{r_ver} and \code{bioc_ver} arguments are ignored.
 
-\code{bioc_install_repos()} observes the \code{R_BIOC_MIRROR} enironment variable
+\code{bioc_install_repos()} observes the \code{R_BIOC_MIRROR} environment variable
 and also the \code{BioC_mirror} option, which can be set to the desired
 Bioconductor mirror. The option takes precedence if both are set. Its
 default value is \code{https://bioconductor.org}.

--- a/man/bioc_install_repos.Rd
+++ b/man/bioc_install_repos.Rd
@@ -22,7 +22,7 @@ corresponding to \code{r_ver}.}
 object.
 
 \code{bioc_install_repos()} returns a named character vector of the URLs of
-the BioConductor repositories, appropriate for the current or the
+the Bioconductor repositories, appropriate for the current or the
 specified R version.
 }
 \description{
@@ -30,7 +30,7 @@ specified R version.
 specified R version.
 }
 \details{
-\code{bioc_install_repos()} deduces the URLs of the BioConductor repositories.
+\code{bioc_install_repos()} deduces the URLs of the Bioconductor repositories.
 
 Both functions observe the \code{R_BIOC_VERSION} environment variable, which
 can be set to force a Bioconductor version. If this is set, then the

--- a/man/install_bioc.Rd
+++ b/man/install_bioc.Rd
@@ -20,7 +20,7 @@ the release are \sQuote{devel},
 \sQuote{release} (the default if none specified), or numeric release
 numbers (e.g. \sQuote{3.3}).}
 
-\item{mirror}{The bioconductor git mirror to use}
+\item{mirror}{The Bioconductor git mirror to use}
 
 \item{git}{Whether to use the \code{git2r} package, or an external
 git client via system. Default is \code{git2r} if it is installed,

--- a/man/install_bitbucket.Rd
+++ b/man/install_bitbucket.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/install-bitbucket.R
 \name{install_bitbucket}
 \alias{install_bitbucket}
-\title{Install a package directly from bitbucket}
+\title{Install a package directly from Bitbucket}
 \usage{
 install_bitbucket(repo, ref = "master", subdir = NULL,
   auth_user = bitbucket_user(), password = bitbucket_password(),


### PR DESCRIPTION
This fixes some spelling errors found with `spelling::spell_check_package()`. 
In addition I changed the spelling of Bioconductor and Bitbucket to their 'official' spelling according to their respective websites. If you don't agree, I can revert those changes easily.
I'd also suggest adding GitLab and Bioconductor to the DESCRIPTION and README like e.g.
"Download and install R packages stored in 'GitHub', **'GitLab', 'Bioconductor',** 'Bitbucket', or plain 'subversion' or 'git' repositories. [...]" (changes in bold print), but have not made those changes.