### PR TITLE
Pass ellipsis parameters when install dependencies

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * `install_gitlab()` now installs from repositories in subgroups and with dots 
   in their name. `subdir` is now an explicit argument instead of implicit in 
   `repo` (@robertdj, #259, #420).
+* `install()` now passes the ellipsis `...` to `install_deps()` (@Neil-Schneider, #411)
 
 # remotes 2.1.0
 

--- a/R/install.R
+++ b/R/install.R
@@ -23,7 +23,7 @@ install <- function(pkgdir, dependencies, quiet, build, build_opts, build_manual
   install_deps(pkgdir, dependencies = dependencies, quiet = quiet,
     build = build, build_opts = build_opts, build_manual = build_manual,
     build_vignettes = build_vignettes, upgrade = upgrade, repos = repos,
-    type = type)
+    type = type, ...)
 
   if (isTRUE(build)) {
     dir <- tempfile()

--- a/inst/install-github.R
+++ b/inst/install-github.R
@@ -4023,7 +4023,7 @@ function(...) {
     install_deps(pkgdir, dependencies = dependencies, quiet = quiet,
       build = build, build_opts = build_opts, build_manual = build_manual,
       build_vignettes = build_vignettes, upgrade = upgrade, repos = repos,
-      type = type)
+      type = type, ...)
   
     if (isTRUE(build)) {
       dir <- tempfile()

--- a/install-github.R
+++ b/install-github.R
@@ -4023,7 +4023,7 @@ function(...) {
     install_deps(pkgdir, dependencies = dependencies, quiet = quiet,
       build = build, build_opts = build_opts, build_manual = build_manual,
       build_vignettes = build_vignettes, upgrade = upgrade, repos = repos,
-      type = type)
+      type = type, ...)
   
     if (isTRUE(build)) {
       dir <- tempfile()


### PR DESCRIPTION
This PR is related to #411. I ran across this when trying to install packages in an instance without docs, so the INSTALL_opts were not propagating. I fixed this before I realized that #402 exists but that PR seems to have stalled.

