### PR TITLE
Improve docs for installing latest GitHub release

### DIFF
--- a/R/install-bitbucket.R
+++ b/R/install-bitbucket.R
@@ -12,6 +12,11 @@
 #' @param password your password. Defaults to the `BITBUCKET_PASSWORD`
 #'   environment variable. See details for further information on setting
 #'   up a password.
+#' @param repo Repository address in the format
+#'   `username/repo[/subdir][@@ref]`. Alternatively, you can
+#'   specify `subdir` and/or `ref` using the respective parameters
+#'   (see below); if both are specified, the values in `repo` take
+#'   precedence.
 #' @param ref Desired git reference; could be a commit, tag, or branch name.
 #'   Defaults to master.
 #' @seealso Bitbucket API docs:

--- a/R/install-github.R
+++ b/R/install-github.R
@@ -4,12 +4,13 @@
 #' packages in a single command.
 #'
 #' @param repo Repository address in the format
-#'   `username/repo[/subdir][@@ref|#pull]`. Alternatively, you can
+#'   `username/repo[/subdir][@@ref|#pull|@@*release]`. Alternatively, you can
 #'   specify `subdir` and/or `ref` using the respective parameters
-#'   (see below); if both is specified, the values in `repo` take
+#'   (see below); if both are specified, the values in `repo` take
 #'   precedence.
 #' @param ref Desired git reference. Could be a commit, tag, or branch
-#'   name, or a call to [github_pull()]. Defaults to `"master"`.
+#'   name, or a call to [github_pull()] or [github_release()]. Defaults to
+#'   `"master"`.
 #' @param subdir subdirectory within repo that contains the R package.
 #' @param auth_token To install from a private repo, generate a personal
 #'   access token (PAT) in "https://github.com/settings/tokens" and
@@ -34,7 +35,7 @@
 #' install_github("wch/ggplot2")
 #' install_github(c("rstudio/httpuv", "rstudio/shiny"))
 #' install_github(c("hadley/httr@@v0.4", "klutometis/roxygen#142",
-#'   "mfrasca/r-logging/pkg"))
+#'   "r-lib/roxygen2@@*release", "mfrasca/r-logging/pkg"))
 #'
 #' # To install from a private repo, use auth_token with a token
 #' # from https://github.com/settings/tokens. You only need the

--- a/man/install_bitbucket.Rd
+++ b/man/install_bitbucket.Rd
@@ -26,9 +26,9 @@ install_bitbucket(
 }
 \arguments{
 \item{repo}{Repository address in the format
-\verb{username/repo[/subdir][@ref|#pull]}. Alternatively, you can
+\verb{username/repo[/subdir][@ref]}. Alternatively, you can
 specify \code{subdir} and/or \code{ref} using the respective parameters
-(see below); if both is specified, the values in \code{repo} take
+(see below); if both are specified, the values in \code{repo} take
 precedence.}
 
 \item{ref}{Desired git reference; could be a commit, tag, or branch name.

--- a/man/install_github.Rd
+++ b/man/install_github.Rd
@@ -25,13 +25,14 @@ install_github(
 }
 \arguments{
 \item{repo}{Repository address in the format
-\verb{username/repo[/subdir][@ref|#pull]}. Alternatively, you can
+\verb{username/repo[/subdir][@ref|#pull|@*release]}. Alternatively, you can
 specify \code{subdir} and/or \code{ref} using the respective parameters
-(see below); if both is specified, the values in \code{repo} take
+(see below); if both are specified, the values in \code{repo} take
 precedence.}
 
 \item{ref}{Desired git reference. Could be a commit, tag, or branch
-name, or a call to \code{\link[=github_pull]{github_pull()}}. Defaults to \code{"master"}.}
+name, or a call to \code{\link[=github_pull]{github_pull()}} or \code{\link[=github_release]{github_release()}}. Defaults to
+\code{"master"}.}
 
 \item{subdir}{subdirectory within repo that contains the R package.}
 
@@ -94,7 +95,7 @@ install_github("klutometis/roxygen")
 install_github("wch/ggplot2")
 install_github(c("rstudio/httpuv", "rstudio/shiny"))
 install_github(c("hadley/httr@v0.4", "klutometis/roxygen#142",
-  "mfrasca/r-logging/pkg"))
+  "r-lib/roxygen2@*release", "mfrasca/r-logging/pkg"))
 
 # To install from a private repo, use auth_token with a token
 # from https://github.com/settings/tokens. You only need the


### PR DESCRIPTION
The README mentions how to install the latest GitHub release, but this functionality doesn't appear in the documentation for `install_github()`.

Also, the documentation for `install_bitbucket()` describes how to install a PR branch, but this isn't possible for BitBucket.

This PR resolves these two issues.