### PR TITLE
Fix an issue in the R -> Bioc version mapping

### DIFF
--- a/R/bioc-standalone.R
+++ b/R/bioc-standalone.R
@@ -64,7 +64,8 @@
 #'
 #' \section{NEWS:}
 #' * 2019-05-30 First version in remotes.
-#'
+#' * 2020-03-22 get_matching_bioc_version() is now correct if the current
+#'              R version is not in the builtin mapping.
 #'
 #' @name bioconductor
 #' @keywords internal
@@ -200,10 +201,24 @@ bioconductor <- local({
     if (minor %in% names(builtin_map)) return(builtin_map[[minor]])
 
     # If we are not in the map, then we need to look this up in
-    # YAML data.
+    # YAML data. It is possible that the current R version matches multiple
+    # Bioc versions. Then we choose the latest released version. If none
+    # of them were released (e.g. they are 'devel' and 'future'), then
+    # we'll use the 'devel' version.
 
     map <- get_version_map(forget = forget)
-    mine <- match(package_version(minor), map$r_version)
+    mine <- which(package_version(minor) == map$r_version)
+    if (length(mine) == 0) {
+      mine <- NA
+    } else if (length(mine) > 1) {
+      if ("release" %in% map$bioc_status[mine]) {
+        mine <- mine["release" == map$bioc_status[mine]]
+      } else if ("devel" %in% map$bioc_status[mine]) {
+        mine <- mine["devel" == map$bioc_status[mine]]
+      } else {
+        mine <- rev(mine)[1]
+      }
+    }
     if (!is.na(mine)) return(map$bioc_version[mine])
 
     # If it is not even in the YAML, then it must be some very old


### PR DESCRIPTION
If the current R version is not in the builtin table, then the
map might contain an R version twice, and we need a more
sophisticated way to choose the right Bioc version.