### PR TITLE
Make install_*() abortable

### DIFF
--- a/R/deps.R
+++ b/R/deps.R
@@ -593,7 +593,13 @@ upgradable_packages <- function(x, upgrade, quiet, is_interactive = interactive(
         choices <- c("All", "CRAN packages only", "None", choices)
       }
 
+      choices <- c(choices, "Abort")
+
       res <- select_menu(choices, title = "These packages have more recent versions available.\nIt is recommended to update all of them.\nWhich would you like to update?")
+
+      if ("Abort" %in% res) {
+        stop("Aborted by user.", call. = FALSE)
+      }
 
       if ("None" %in% res || length(res) == 0) {
         return(x[uninstalled, ])


### PR DESCRIPTION
because it's notoriously difficult to abort otherwise, at least in RStudio.

I'm using devmode, CRAN packages go to the "stable" library, GitHub packages to the "dev" one. If an update is required, I never want to upgrade packages from CRAN (because they would land in "dev"), instead I want to upgrade "stable" manually before proceeding.