### PR TITLE
vignette: update sample Bitbucket path

### DIFF
--- a/vignettes/dependencies.Rmd
+++ b/vignettes/dependencies.Rmd
@@ -71,10 +71,10 @@ Also' section in `?install_github` for a complete list.
 Remotes: gitlab::jimhester/covr
 
 # Git
-Remotes: git::git@bitbucket.org:dannavarro/lsr-package.git
+Remotes: git::git@bitbucket.org:djnavarro/lsr.git
 
 # Bitbucket
-Remotes: bitbucket::sulab/mygene.r@default, dannavarro/lsr-package
+Remotes: bitbucket::sulab/mygene.r@default, djnavarro/lsr
 
 # Bioconductor
 Remotes: bioc::3.3/SummarizedExperiment#117513, bioc::release/Biobase


### PR DESCRIPTION
...because `lsr` has moved.

(I realize these are just for illustration, but having the examples all resolve to real URLs definitely helps me understand the syntax)