### PR TITLE
Return dependencies in the reverse order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,3 +8,6 @@ inst/install-github.R: inst/install-github.Rin $(SRC)
 
 install-github.R: inst/install-github.R
 	cp $< $@
+
+clean:
+	rm inst/install-github.R install-github.R

--- a/R/deps.R
+++ b/R/deps.R
@@ -379,10 +379,9 @@ find_deps <- function(packages, available = available_packages(),
     rec_flat <- character()
   }
 
-  # We need to put the recursive dependencies _before_ the top dependencies and
-  # input packages, to ensure that any dependencies are installed before
-  # their parents are loaded.
-  unique(c(rec_flat, top_flat, if (include_pkgs) packages))
+  # We need to return these in reverse order, so that the packages furthest
+  # down in the tree are installed first.
+  unique(rev(c(if (include_pkgs) packages, top_flat, rec_flat)))
 }
 
 #' Standardise dependencies using the same logical as [install.packages]

--- a/inst/install-github.R
+++ b/inst/install-github.R
@@ -911,10 +911,9 @@ function(...) {
       rec_flat <- character()
     }
   
-    # We need to put the recursive dependencies _before_ the top dependencies and
-    # input packages, to ensure that any dependencies are installed before
-    # their parents are loaded.
-    unique(c(rec_flat, top_flat, if (include_pkgs) packages))
+    # We need to return these in reverse order, so that the packages furthest
+    # down in the tree are installed first.
+    unique(rev(c(if (include_pkgs) packages, top_flat, rec_flat)))
   }
   
   #' Standardise dependencies using the same logical as [install.packages]

--- a/install-github.R
+++ b/install-github.R
@@ -911,10 +911,9 @@ function(...) {
       rec_flat <- character()
     }
   
-    # We need to put the recursive dependencies _before_ the top dependencies and
-    # input packages, to ensure that any dependencies are installed before
-    # their parents are loaded.
-    unique(c(rec_flat, top_flat, if (include_pkgs) packages))
+    # We need to return these in reverse order, so that the packages furthest
+    # down in the tree are installed first.
+    unique(rev(c(if (include_pkgs) packages, top_flat, rec_flat)))
   }
   
   #' Standardise dependencies using the same logical as [install.packages]


### PR DESCRIPTION
I am hopeful this will be a robust fix for the errors when installing mixed source and binary packages, e.g. #301 

Other previous fixes worked around part of the problem, but really the underlying issue is that `tools::package_dependencies(recursive = TRUE)` just returns the unique dependencies in the order they are in the database. Because the dependencies in child nodes are always after their parents this means they are installed in the wrong order.

In the cases where `install.packages()` is installing only source packages or only binary packages there is no issue, as `install.packages()` handles the ordering internally for source packages, and the order you install binary packages doesn't matter.

I believe returning the dependencies in the reverse order should ensure that child dependencies always come before their parents, which is the root cause of this issue.