### PR TITLE
escape hyphen for compatibility with PCRE 2 (for R 4.0.0)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 # remotes (development version)
 
+* `parse_submodules()` internal regular expression is now PCRE 2 compatible (#502, @jan-glx)
+
 * Another fix for the mixed binary and source dependency issue, it should hopefully be fully squashed now (#296)
+
 * The upgrade menu is now interruptible in RStudio (#489)
 
 # remotes 2.1.1

--- a/R/submodule.R
+++ b/R/submodule.R
@@ -25,7 +25,7 @@ parse_submodules <- function(file) {
   # Extract name = value
   # The variable names are case-insensitive, allow only alphanumeric characters
   # and -, and must start with an alphabetic character.
-  variable_name <- "[[:alpha:]][[:alnum:]-]*"
+  variable_name <- "[[:alpha:]][[:alnum:]\\-]*"
   mapping_values <- re_match(
     x,
     sprintf('^[[:space:]]*(?<name>%s)[[:space:]]*=[[:space:]]*(?<value>.*)[[:space:]]*$', variable_name),

--- a/inst/install-github.R
+++ b/inst/install-github.R
@@ -4627,7 +4627,7 @@ function(...) {
     # Extract name = value
     # The variable names are case-insensitive, allow only alphanumeric characters
     # and -, and must start with an alphabetic character.
-    variable_name <- "[[:alpha:]][[:alnum:]-]*"
+    variable_name <- "[[:alpha:]][[:alnum:]\\-]*"
     mapping_values <- re_match(
       x,
       sprintf('^[[:space:]]*(?<name>%s)[[:space:]]*=[[:space:]]*(?<value>.*)[[:space:]]*$', variable_name),

--- a/install-github.R
+++ b/install-github.R
@@ -4627,7 +4627,7 @@ function(...) {
     # Extract name = value
     # The variable names are case-insensitive, allow only alphanumeric characters
     # and -, and must start with an alphabetic character.
-    variable_name <- "[[:alpha:]][[:alnum:]-]*"
+    variable_name <- "[[:alpha:]][[:alnum:]\\-]*"
     mapping_values <- re_match(
       x,
       sprintf('^[[:space:]]*(?<name>%s)[[:space:]]*=[[:space:]]*(?<value>.*)[[:space:]]*$', variable_name),


### PR DESCRIPTION
PCRE 2 is the new default for[ R 4.0.0](https://cran.r-project.org/doc/manuals/r-devel/NEWS.html):

> PCRE2 reports errors for some regular expressions that were accepted by PCRE1. A hyphen now has to be escaped in a character class to be interpreted as a literal (unless first or last in the class definition). \R, \B and \X are no longer allowed in character classes (PCRE1 treated these as literals).

without this fix installation of packages with submodules will fail. For example, when installing `emo`:
```R
> devtools::install_github("hadley/emo")
Downloading GitHub repo hadley/emo@master
Error: Failed to install 'emo' from GitHub:
  invalid regular expression '^[[:space:]]*(?<name>[[:alpha:]][[:alnum:]-]*)[[:space:]]*=[[:space:]]*(?<value>.*)[[:space:]]*$'
In addition: Warning message:
In regexpr(pattern, text, perl = perl, ...) :
  PCRE pattern compilation error
	'invalid range in character class'
	at '-]*)[[:space:]]*=[[:space:]]*(?<value>.*)[[:space:]]*$'
```

Demonstration of the fix:
```
> .gitmodules_example <- c("[submodule \"data-raw/gemoji\"]","\tpath = data-raw/gemoji","\turl = https://github.com/github/gemoji.git", "[submodule \"data-raw/emojilib\"]")
> regexpr("^[[:space:]]*(?<name>[[:alpha:]][[:alnum:]-]*)[[:space:]]*=[[:space:]]*(?<value>.*)[[:space:]]*$", .gitmodules_example, perl =TRUE)
Error in regexpr("^[[:space:]]*(?<name>[[:alpha:]][[:alnum:]-]*)[[:space:]]*=[[:space:]]*(?<value>.*)[[:space:]]*$",  : 
  invalid regular expression '^[[:space:]]*(?<name>[[:alpha:]][[:alnum:]-]*)[[:space:]]*=[[:space:]]*(?<value>.*)[[:space:]]*$'
In addition: Warning message:
In regexpr("^[[:space:]]*(?<name>[[:alpha:]][[:alnum:]-]*)[[:space:]]*=[[:space:]]*(?<value>.*)[[:space:]]*$",  :
  PCRE pattern compilation error
	'invalid range in character class'
	at '-]*)[[:space:]]*=[[:space:]]*(?<value>.*)[[:space:]]*$'
> regexpr("^[[:space:]]*(?<name>[[:alpha:]][[:alnum:]\\-]*)[[:space:]]*=[[:space:]]*(?<value>.*)[[:space:]]*$", .gitmodules_example, perl =TRUE)
[1] -1  1  1 -1
attr(,"match.length")
[1] -1 23 43 -1
attr(,"index.type")
[1] "chars"
attr(,"useBytes")
[1] TRUE
attr(,"capture.start")
     name value
[1,]   -1    -1
[2,]    2     9
[3,]    2     8
[4,]   -1    -1
attr(,"capture.length")
     name value
[1,]   -1    -1
[2,]    4    15
[3,]    3    36
[4,]   -1    -1
attr(,"capture.names")
[1] "name"  "value"
```
