### PR TITLE
Remotes without package names are now unconditionally installed again

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # remotes (development version)
 
+* remotes without package names are now unconditionally installed (#532, @jakubkovac)
+
 * `install_*()` functions will no longer fail by default if there warnings from `install.packages()`. Concretely the default value of `R_REMOTES_NO_ERRORS_FROM_WARNINGS` has changed to `true` from the previous value of `false`. (#403)
 
 # remotes 2.2.0

--- a/R/deps.R
+++ b/R/deps.R
@@ -144,7 +144,7 @@ dev_package_deps <- function(pkgdir = ".", dependencies = NA,
 
   res <- do.call(rbind, c(list(res), lapply(get_extra_deps(pkg, dependencies), extra_deps, pkg = pkg), stringsAsFactors = FALSE))
 
-  res[!duplicated(res$package, fromLast = TRUE), ]
+  res[is.na(res$package) | !duplicated(res$package, fromLast = TRUE), ]
 }
 
 combine_remote_deps <- function(cran_deps, remote_deps) {

--- a/tests/testthat/test-deps.R
+++ b/tests/testthat/test-deps.R
@@ -536,3 +536,13 @@ test_that("dev_package_deps can retrieve custom fields", {
   expect_true(any(is_covr))
   expect_is(res$remote[is_covr][[1]], "cran_remote")
 })
+
+test_that("dev_package_deps works with url remotes", {
+  skip_on_cran()
+  skip_if_offline()
+
+  res <- dev_package_deps(test_path("urlremotes"), dependencies = TRUE)
+
+  expect_equal(sum(is.na(res$package)), 2)
+
+})

--- a/tests/testthat/urlremotes/DESCRIPTION
+++ b/tests/testthat/urlremotes/DESCRIPTION
@@ -1,0 +1,15 @@
+Package: noremotes
+Title: Tools to make developing R code easier
+License: MIT
+Description: Package description.
+Author: Bugs Bunny
+Maintainer: Bugs Bunny <bunny@acme.com>
+Version: 1.0.0
+Suggests: testthat
+Imports:
+  example,
+  dtplyr
+Remotes:
+  url::https://www.example.com/,
+  url::https://github.com/tidyverse/dtplyr
+


### PR DESCRIPTION
fixes #530
fixes #246

Sorry had to open this again I destroyed my git history. I've added a simple test and dummy description file.