### PR TITLE
Allow for GITHUB_TOKEN to be detected in the environment configuration

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 * `install_*()` functions will no longer fail by default if there warnings from `install.packages()`. Concretely the default value of `R_REMOTES_NO_ERRORS_FROM_WARNINGS` has changed to `true` from the previous value of `false`. (#403)
 
+
+* `github_pat()` will now check if `GITHUB_TOKEN` is set if it cannot find `GITHUB_PAT`. (@coatless)
+
 # remotes 2.2.0
 
 ##  New functions and features

--- a/R/github.R
+++ b/R/github.R
@@ -64,18 +64,25 @@ github_commit <- function(username, repo, ref = "HEAD",
 #' Retrieve Github personal access token.
 #'
 #' A github personal access token
-#' Looks in env var `GITHUB_PAT`
+#' Looks in env var `GITHUB_PAT` or `GITHUB_TOKEN`.
 #'
 #' @keywords internal
 #' @noRd
 github_pat <- function(quiet = TRUE) {
-  pat <- Sys.getenv("GITHUB_PAT")
 
-  if (nzchar(pat)) {
-    if (!quiet) {
-      message("Using github PAT from envvar GITHUB_PAT")
+  env_var_aliases <- c(
+    "GITHUB_PAT",
+    "GITHUB_TOKEN"
+  )
+
+  for (env_var in env_var_aliases) {
+    pat <- Sys.getenv(env_var)
+    if (nzchar(pat)) {
+      if (!quiet) {
+        message("Using github PAT from envvar ", env_var)
+      }
+      return(pat)
     }
-    return(pat)
   }
 
   if (in_ci()) {

--- a/tests/testthat/test-github.R
+++ b/tests/testthat/test-github.R
@@ -7,13 +7,21 @@ test_that("github_pat", {
   expect_equal(github_pat(), "badcafe")
   expect_message(github_pat(quiet = FALSE), "Using github PAT from envvar GITHUB_PAT")
 
+  # Check standard GITHUB_PAT
   withr::with_envvar(c(GITHUB_PAT=NA, CI=NA), {
      expect_equal(github_pat(), NULL)
   })
 
+  # Check for embedded token
   withr::with_envvar(c(GITHUB_PAT=NA, CI="true"), {
     expect_true(nzchar(github_pat()))
   })
+
+  # Check for GITHUB_TOKEN
+  withr::with_envvar(c(GITHUB_PAT=NA, GITHUB_TOKEN="hi!", CI=NA), {
+    expect_true(nzchar(github_pat()))
+  })
+
   expect_true(nzchar(github_pat()))
 })
 


### PR DESCRIPTION
Modifies `github_pat()` by allowing for a list of aliases if `GITHUB_PAT` isn't detected. Most notably, checks for the 
presence of `GITHUB_TOKEN` in the environment. 