### PR TITLE
Respect custom hosts

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # remotes (development version)
 
+* It is now possible to specify a custom host for dependencies listed in the `DESCRIPTION` file with `Remotes: <type>[@host]::<username>/<repo>[@ref]`. The `ref` now supports `/` in it for `GitLab` repositories as it did for `GitHub`repositories. (@dagola, #448)
+
 * `install_*()` functions will no longer fail by default if there warnings from `install.packages()`. Concretely the default value of `R_REMOTES_NO_ERRORS_FROM_WARNINGS` has changed to `true` from the previous value of `false`. (#403)
 
 * `system_requirements()` now supports querying released packages as well as development dependencies (#545)

--- a/R/deps.R
+++ b/R/deps.R
@@ -532,6 +532,16 @@ parse_one_extra <- function(x, ...) {
   } else {
     stop("Malformed remote specification '", x, "'", call. = FALSE)
   }
+
+  if (grepl("@", type)) {
+    # Custom host
+    tah <- strsplit(type, "@", fixed = TRUE)[[1]]
+    type <- tah[1]
+    host <- tah[2]
+  } else {
+    host <- NULL
+  }
+
   tryCatch({
     # We need to use `environment(sys.function())` instead of
     # `asNamespace("remotes")` because when used as a script in
@@ -539,7 +549,11 @@ parse_one_extra <- function(x, ...) {
 
     fun <- get(paste0(tolower(type), "_remote"), mode = "function", inherits = TRUE)
 
-    res <- fun(repo, ...)
+    if (!is.null(host)) {
+      res <- fun(repo, host = host, ...)
+    } else {
+      res <- fun(repo, ...)
+    }
     }, error = function(e) stop("Unknown remote type: ", type, "\n  ", conditionMessage(e), call. = FALSE)
   )
   res

--- a/R/deps.R
+++ b/R/deps.R
@@ -24,12 +24,13 @@
 #'   - Config/Needs/website - for dependencies used in building the pkgdown site.
 #'   - Config/Needs/coverage for dependencies used in calculating test coverage.
 #' @param quiet If `TRUE`, suppress output.
-#' @param upgrade One of "default", "ask", "always", or "never". "default"
-#'   respects the value of the `R_REMOTES_UPGRADE` environment variable if set,
-#'   and falls back to "ask" if unset. "ask" prompts the user for which out of
-#'   date packages to upgrade. For non-interactive sessions "ask" is equivalent
-#'   to "always". `TRUE` and `FALSE` are also accepted and correspond to
-#'   "always" and "never" respectively.
+#' @param upgrade Should package dependencies be upgraded? One of "default",
+#'   "ask", "always", or "never". "default" respects the value of the
+#'   `R_REMOTES_UPGRADE` environment variable if set, and falls back to "ask" if
+#'   unset. "ask" prompts the user for which out of date packages to upgrade.
+#'   For non-interactive sessions "ask" is equivalent to "always". `TRUE` and
+#'   `FALSE` are also accepted and correspond to "always" and "never"
+#'   respectively.
 #' @param repos A character vector giving repositories to use.
 #' @param type Type of package to `update`.
 #'

--- a/R/github.R
+++ b/R/github.R
@@ -28,7 +28,7 @@ github_GET <- function(path, ..., host = "api.github.com", pat = github_pat(), u
 github_commit <- function(username, repo, ref = "HEAD",
   host = "api.github.com", pat = github_pat(), use_curl = !is_standalone() && pkg_installed("curl"), current_sha = NULL) {
 
-  url <- build_url(host, "repos", utils::URLencode(paste0(username, "/", repo), reserved = TRUE), "commits", utils::URLencode(ref, reserved = TRUE))
+  url <- build_url(host, "repos", username, repo, "commits", utils::URLencode(ref, reserved = TRUE))
 
   if (isTRUE(use_curl)) {
     h <- curl::new_handle()

--- a/R/github.R
+++ b/R/github.R
@@ -28,7 +28,7 @@ github_GET <- function(path, ..., host = "api.github.com", pat = github_pat(), u
 github_commit <- function(username, repo, ref = "HEAD",
   host = "api.github.com", pat = github_pat(), use_curl = !is_standalone() && pkg_installed("curl"), current_sha = NULL) {
 
-  url <- build_url(host, "repos", username, repo, "commits", utils::URLencode(ref, reserved = TRUE))
+  url <- build_url(host, "repos", utils::URLencode(paste0(username, "/", repo), reserved = TRUE), "commits", utils::URLencode(ref, reserved = TRUE))
 
   if (isTRUE(use_curl)) {
     h <- curl::new_handle()

--- a/R/install-gitlab.R
+++ b/R/install-gitlab.R
@@ -178,7 +178,7 @@ gitlab_pat <- function(quiet = TRUE) {
 gitlab_project_id <- function(username, repo, ref = "HEAD",
   host = "gitlab.com", pat = gitlab_pat()) {
 
-  url <- build_url(host, "api", "v4", "projects", utils::URLencode(paste0(username, "/", repo), reserved = TRUE), "repository", "commits", ref)
+  url <- build_url(host, "api", "v4", "projects", utils::URLencode(paste0(username, "/", repo), reserved = TRUE), "repository", "commits", utils::URLencode(ref, reserved = TRUE))
 
   tmp <- tempfile()
   download(tmp, url, headers = c("Private-Token" = pat))

--- a/R/install-gitlab.R
+++ b/R/install-gitlab.R
@@ -125,7 +125,7 @@ remote_package_name.gitlab_remote <- function(remote, ...) {
       is.null(remote$subdir),
       "DESCRIPTION",
       utils::URLencode(paste0(remote$subdir, "/DESCRIPTION"), reserved = TRUE)),
-    "/raw?ref=", remote$ref)
+    "/raw?ref=", utils::URLencode(remote$ref, reserved = TRUE))
 
   dest <- tempfile()
   res <- download(dest, src, headers = c("Private-Token" = remote$auth_token))

--- a/R/install-gitlab.R
+++ b/R/install-gitlab.R
@@ -149,7 +149,7 @@ format.gitlab_remote <- function(x, ...) {
 gitlab_commit <- function(username, repo, ref = "HEAD",
   host = "gitlab.com", pat = gitlab_pat()) {
 
-  url <- build_url(host, "api", "v4", "projects", utils::URLencode(paste0(username, "/", repo), reserved = TRUE), "repository", "commits", ref)
+  url <- build_url(host, "api", "v4", "projects", utils::URLencode(paste0(username, "/", repo), reserved = TRUE), "repository", "commits", utils::URLencode(ref, reserved = TRUE))
 
   tmp <- tempfile()
   download(tmp, url, headers = c("Private-Token" = pat))

--- a/inst/install-github.R
+++ b/inst/install-github.R
@@ -556,12 +556,13 @@ function(...) {
   #'   - Config/Needs/website - for dependencies used in building the pkgdown site.
   #'   - Config/Needs/coverage for dependencies used in calculating test coverage.
   #' @param quiet If `TRUE`, suppress output.
-  #' @param upgrade One of "default", "ask", "always", or "never". "default"
-  #'   respects the value of the `R_REMOTES_UPGRADE` environment variable if set,
-  #'   and falls back to "ask" if unset. "ask" prompts the user for which out of
-  #'   date packages to upgrade. For non-interactive sessions "ask" is equivalent
-  #'   to "always". `TRUE` and `FALSE` are also accepted and correspond to
-  #'   "always" and "never" respectively.
+  #' @param upgrade Should package dependencies be upgraded? One of "default",
+  #'   "ask", "always", or "never". "default" respects the value of the
+  #'   `R_REMOTES_UPGRADE` environment variable if set, and falls back to "ask" if
+  #'   unset. "ask" prompts the user for which out of date packages to upgrade.
+  #'   For non-interactive sessions "ask" is equivalent to "always". `TRUE` and
+  #'   `FALSE` are also accepted and correspond to "always" and "never"
+  #'   respectively.
   #' @param repos A character vector giving repositories to use.
   #' @param type Type of package to `update`.
   #'

--- a/inst/install-github.R
+++ b/inst/install-github.R
@@ -3290,7 +3290,7 @@ function(...) {
   gitlab_project_id <- function(username, repo, ref = "HEAD",
     host = "gitlab.com", pat = gitlab_pat()) {
   
-    url <- build_url(host, "api", "v4", "projects", utils::URLencode(paste0(username, "/", repo), reserved = TRUE), "repository", "commits", ref)
+    url <- build_url(host, "api", "v4", "projects", utils::URLencode(paste0(username, "/", repo), reserved = TRUE), "repository", "commits", utils::URLencode(ref, reserved = TRUE))
   
     tmp <- tempfile()
     download(tmp, url, headers = c("Private-Token" = pat))

--- a/inst/install-github.R
+++ b/inst/install-github.R
@@ -1709,7 +1709,7 @@ function(...) {
   github_commit <- function(username, repo, ref = "HEAD",
     host = "api.github.com", pat = github_pat(), use_curl = !is_standalone() && pkg_installed("curl"), current_sha = NULL) {
   
-    url <- build_url(host, "repos", utils::URLencode(paste0(username, "/", repo), reserved = TRUE), "commits", utils::URLencode(ref, reserved = TRUE))
+    url <- build_url(host, "repos", username, repo, "commits", utils::URLencode(ref, reserved = TRUE))
   
     if (isTRUE(use_curl)) {
       h <- curl::new_handle()

--- a/inst/install-github.R
+++ b/inst/install-github.R
@@ -1064,6 +1064,16 @@ function(...) {
     } else {
       stop("Malformed remote specification '", x, "'", call. = FALSE)
     }
+  
+    if (grepl("@", type)) {
+      # Custom host
+      tah <- strsplit(type, "@", fixed = TRUE)[[1]]
+      type <- tah[1]
+      host <- tah[2]
+    } else {
+      host <- NULL
+    }
+  
     tryCatch({
       # We need to use `environment(sys.function())` instead of
       # `asNamespace("remotes")` because when used as a script in
@@ -1071,7 +1081,11 @@ function(...) {
   
       fun <- get(paste0(tolower(type), "_remote"), mode = "function", inherits = TRUE)
   
-      res <- fun(repo, ...)
+      if (!is.null(host)) {
+        res <- fun(repo, host = host, ...)
+      } else {
+        res <- fun(repo, ...)
+      }
       }, error = function(e) stop("Unknown remote type: ", type, "\n  ", conditionMessage(e), call. = FALSE)
     )
     res

--- a/inst/install-github.R
+++ b/inst/install-github.R
@@ -3237,7 +3237,7 @@ function(...) {
         is.null(remote$subdir),
         "DESCRIPTION",
         utils::URLencode(paste0(remote$subdir, "/DESCRIPTION"), reserved = TRUE)),
-      "/raw?ref=", remote$ref)
+      "/raw?ref=", utils::URLencode(remote$ref, reserved = TRUE))
   
     dest <- tempfile()
     res <- download(dest, src, headers = c("Private-Token" = remote$auth_token))

--- a/inst/install-github.R
+++ b/inst/install-github.R
@@ -1709,7 +1709,7 @@ function(...) {
   github_commit <- function(username, repo, ref = "HEAD",
     host = "api.github.com", pat = github_pat(), use_curl = !is_standalone() && pkg_installed("curl"), current_sha = NULL) {
   
-    url <- build_url(host, "repos", username, repo, "commits", utils::URLencode(ref, reserved = TRUE))
+    url <- build_url(host, "repos", utils::URLencode(paste0(username, "/", repo), reserved = TRUE), "commits", utils::URLencode(ref, reserved = TRUE))
   
     if (isTRUE(use_curl)) {
       h <- curl::new_handle()
@@ -3261,7 +3261,7 @@ function(...) {
   gitlab_commit <- function(username, repo, ref = "HEAD",
     host = "gitlab.com", pat = gitlab_pat()) {
   
-    url <- build_url(host, "api", "v4", "projects", utils::URLencode(paste0(username, "/", repo), reserved = TRUE), "repository", "commits", ref)
+    url <- build_url(host, "api", "v4", "projects", utils::URLencode(paste0(username, "/", repo), reserved = TRUE), "repository", "commits", utils::URLencode(ref, reserved = TRUE))
   
     tmp <- tempfile()
     download(tmp, url, headers = c("Private-Token" = pat))

--- a/install-github.R
+++ b/install-github.R
@@ -556,12 +556,13 @@ function(...) {
   #'   - Config/Needs/website - for dependencies used in building the pkgdown site.
   #'   - Config/Needs/coverage for dependencies used in calculating test coverage.
   #' @param quiet If `TRUE`, suppress output.
-  #' @param upgrade One of "default", "ask", "always", or "never". "default"
-  #'   respects the value of the `R_REMOTES_UPGRADE` environment variable if set,
-  #'   and falls back to "ask" if unset. "ask" prompts the user for which out of
-  #'   date packages to upgrade. For non-interactive sessions "ask" is equivalent
-  #'   to "always". `TRUE` and `FALSE` are also accepted and correspond to
-  #'   "always" and "never" respectively.
+  #' @param upgrade Should package dependencies be upgraded? One of "default",
+  #'   "ask", "always", or "never". "default" respects the value of the
+  #'   `R_REMOTES_UPGRADE` environment variable if set, and falls back to "ask" if
+  #'   unset. "ask" prompts the user for which out of date packages to upgrade.
+  #'   For non-interactive sessions "ask" is equivalent to "always". `TRUE` and
+  #'   `FALSE` are also accepted and correspond to "always" and "never"
+  #'   respectively.
   #' @param repos A character vector giving repositories to use.
   #' @param type Type of package to `update`.
   #'

--- a/install-github.R
+++ b/install-github.R
@@ -3290,7 +3290,7 @@ function(...) {
   gitlab_project_id <- function(username, repo, ref = "HEAD",
     host = "gitlab.com", pat = gitlab_pat()) {
   
-    url <- build_url(host, "api", "v4", "projects", utils::URLencode(paste0(username, "/", repo), reserved = TRUE), "repository", "commits", ref)
+    url <- build_url(host, "api", "v4", "projects", utils::URLencode(paste0(username, "/", repo), reserved = TRUE), "repository", "commits", utils::URLencode(ref, reserved = TRUE))
   
     tmp <- tempfile()
     download(tmp, url, headers = c("Private-Token" = pat))

--- a/install-github.R
+++ b/install-github.R
@@ -1709,7 +1709,7 @@ function(...) {
   github_commit <- function(username, repo, ref = "HEAD",
     host = "api.github.com", pat = github_pat(), use_curl = !is_standalone() && pkg_installed("curl"), current_sha = NULL) {
   
-    url <- build_url(host, "repos", utils::URLencode(paste0(username, "/", repo), reserved = TRUE), "commits", utils::URLencode(ref, reserved = TRUE))
+    url <- build_url(host, "repos", username, repo, "commits", utils::URLencode(ref, reserved = TRUE))
   
     if (isTRUE(use_curl)) {
       h <- curl::new_handle()

--- a/install-github.R
+++ b/install-github.R
@@ -1064,6 +1064,16 @@ function(...) {
     } else {
       stop("Malformed remote specification '", x, "'", call. = FALSE)
     }
+  
+    if (grepl("@", type)) {
+      # Custom host
+      tah <- strsplit(type, "@", fixed = TRUE)[[1]]
+      type <- tah[1]
+      host <- tah[2]
+    } else {
+      host <- NULL
+    }
+  
     tryCatch({
       # We need to use `environment(sys.function())` instead of
       # `asNamespace("remotes")` because when used as a script in
@@ -1071,7 +1081,11 @@ function(...) {
   
       fun <- get(paste0(tolower(type), "_remote"), mode = "function", inherits = TRUE)
   
-      res <- fun(repo, ...)
+      if (!is.null(host)) {
+        res <- fun(repo, host = host, ...)
+      } else {
+        res <- fun(repo, ...)
+      }
       }, error = function(e) stop("Unknown remote type: ", type, "\n  ", conditionMessage(e), call. = FALSE)
     )
     res

--- a/install-github.R
+++ b/install-github.R
@@ -3237,7 +3237,7 @@ function(...) {
         is.null(remote$subdir),
         "DESCRIPTION",
         utils::URLencode(paste0(remote$subdir, "/DESCRIPTION"), reserved = TRUE)),
-      "/raw?ref=", remote$ref)
+      "/raw?ref=", utils::URLencode(remote$ref, reserved = TRUE))
   
     dest <- tempfile()
     res <- download(dest, src, headers = c("Private-Token" = remote$auth_token))

--- a/install-github.R
+++ b/install-github.R
@@ -1709,7 +1709,7 @@ function(...) {
   github_commit <- function(username, repo, ref = "HEAD",
     host = "api.github.com", pat = github_pat(), use_curl = !is_standalone() && pkg_installed("curl"), current_sha = NULL) {
   
-    url <- build_url(host, "repos", username, repo, "commits", utils::URLencode(ref, reserved = TRUE))
+    url <- build_url(host, "repos", utils::URLencode(paste0(username, "/", repo), reserved = TRUE), "commits", utils::URLencode(ref, reserved = TRUE))
   
     if (isTRUE(use_curl)) {
       h <- curl::new_handle()
@@ -3261,7 +3261,7 @@ function(...) {
   gitlab_commit <- function(username, repo, ref = "HEAD",
     host = "gitlab.com", pat = gitlab_pat()) {
   
-    url <- build_url(host, "api", "v4", "projects", utils::URLencode(paste0(username, "/", repo), reserved = TRUE), "repository", "commits", ref)
+    url <- build_url(host, "api", "v4", "projects", utils::URLencode(paste0(username, "/", repo), reserved = TRUE), "repository", "commits", utils::URLencode(ref, reserved = TRUE))
   
     tmp <- tempfile()
     download(tmp, url, headers = c("Private-Token" = pat))

--- a/tests/testthat/test-deps.R
+++ b/tests/testthat/test-deps.R
@@ -180,7 +180,7 @@ test_that("Additional_repositories field", {
   )
 
   pkg <- list(
-    additional_repositories = 
+    additional_repositories =
       "\n  http://packages.ropensci.org, \nhttp://foo.bar.com"
   )
 
@@ -344,6 +344,18 @@ test_that("remotes are parsed with explicit types", {
 
   expect_equal(split_extra_deps("bioc::user:password@release/Biobase#12345,github::klutometis/roxygen"),
     c("bioc::user:password@release/Biobase#12345", "github::klutometis/roxygen"))
+
+})
+
+test_that("remotes are parsed with explicit host", {
+
+  expect_equal(
+    parse_one_extra("github@api.github.com::hadley/testthat"),
+    github_remote("hadley/testthat"))
+
+  expect_equal(
+    parse_one_extra("gitlab@gitlab.com::r-packages/psyverse"),
+    gitlab_remote("r-packages/psyverse"))
 
 })
 

--- a/tests/testthat/test-install-gitlab.R
+++ b/tests/testthat/test-install-gitlab.R
@@ -117,6 +117,18 @@ test_that("remote_sha.gitlab_remote", {
     "0f39d9eb735bf16909831c0bb129063dda388375"
   )
 
+  expect_equal(
+    remote_sha(
+      remote("gitlab",
+        host = "https://gitlab.com",
+        username = "drgola",
+        repo = "r_pkg_test",
+        ref = "feature/foo_mult"
+      )
+    ),
+    "58376e96e9b42baece2ab7c0414db6064740c6b6"
+  )
+
 })
 
 test_that("gitlab_project_id", {


### PR DESCRIPTION
In #448  a feature to specify a custom host URL in the Remotes field for e.g. enterprise GitHub or GitLab instances is requested.
This pull request adds a feature to specify the host URL explicitly:
```
<type>[@host]::<username>/<repo>[@ref]
```

The tests added may be not complete in the sense that I was not able to test against a custom host. Maybe anyone can provide some hints for better tests?