### PR TITLE
Add more info on `upgrade` argument

### DIFF
--- a/R/deps.R
+++ b/R/deps.R
@@ -24,7 +24,7 @@
 #'   - Config/Needs/website - for dependencies used in building the pkgdown site.
 #'   - Config/Needs/coverage for dependencies used in calculating test coverage.
 #' @param quiet If `TRUE`, suppress output.
-#' @param upgrade One of "default", "ask", "always", or "never". "default"
+#' @param upgrade Should package dependencies be upgraded? One of "default", "ask", "always", or "never". "default"
 #'   respects the value of the `R_REMOTES_UPGRADE` environment variable if set,
 #'   and falls back to "ask" if unset. "ask" prompts the user for which out of
 #'   date packages to upgrade. For non-interactive sessions "ask" is equivalent

--- a/man/install_bioc.Rd
+++ b/man/install_bioc.Rd
@@ -52,7 +52,7 @@ common ones include:
 \item Config/Needs/coverage for dependencies used in calculating test coverage.
 }}
 
-\item{upgrade}{One of "default", "ask", "always", or "never". "default"
+\item{upgrade}{Should package dependencies be upgraded? One of "default", "ask", "always", or "never". "default"
 respects the value of the \code{R_REMOTES_UPGRADE} environment variable if set,
 and falls back to "ask" if unset. "ask" prompts the user for which out of
 date packages to upgrade. For non-interactive sessions "ask" is equivalent

--- a/man/install_bitbucket.Rd
+++ b/man/install_bitbucket.Rd
@@ -66,7 +66,7 @@ common ones include:
 \item Config/Needs/coverage for dependencies used in calculating test coverage.
 }}
 
-\item{upgrade}{One of "default", "ask", "always", or "never". "default"
+\item{upgrade}{Should package dependencies be upgraded? One of "default", "ask", "always", or "never". "default"
 respects the value of the \code{R_REMOTES_UPGRADE} environment variable if set,
 and falls back to "ask" if unset. "ask" prompts the user for which out of
 date packages to upgrade. For non-interactive sessions "ask" is equivalent

--- a/man/install_cran.Rd
+++ b/man/install_cran.Rd
@@ -44,7 +44,7 @@ common ones include:
 \item Config/Needs/coverage for dependencies used in calculating test coverage.
 }}
 
-\item{upgrade}{One of "default", "ask", "always", or "never". "default"
+\item{upgrade}{Should package dependencies be upgraded? One of "default", "ask", "always", or "never". "default"
 respects the value of the \code{R_REMOTES_UPGRADE} environment variable if set,
 and falls back to "ask" if unset. "ask" prompts the user for which out of
 date packages to upgrade. For non-interactive sessions "ask" is equivalent

--- a/man/install_deps.Rd
+++ b/man/install_deps.Rd
@@ -43,7 +43,7 @@ common ones include:
 
 \item{type}{Type of package to \code{update}.}
 
-\item{upgrade}{One of "default", "ask", "always", or "never". "default"
+\item{upgrade}{Should package dependencies be upgraded? One of "default", "ask", "always", or "never". "default"
 respects the value of the \code{R_REMOTES_UPGRADE} environment variable if set,
 and falls back to "ask" if unset. "ask" prompts the user for which out of
 date packages to upgrade. For non-interactive sessions "ask" is equivalent

--- a/man/install_git.Rd
+++ b/man/install_git.Rd
@@ -60,7 +60,7 @@ common ones include:
 \item Config/Needs/coverage for dependencies used in calculating test coverage.
 }}
 
-\item{upgrade}{One of "default", "ask", "always", or "never". "default"
+\item{upgrade}{Should package dependencies be upgraded? One of "default", "ask", "always", or "never". "default"
 respects the value of the \code{R_REMOTES_UPGRADE} environment variable if set,
 and falls back to "ask" if unset. "ask" prompts the user for which out of
 date packages to upgrade. For non-interactive sessions "ask" is equivalent

--- a/man/install_github.Rd
+++ b/man/install_github.Rd
@@ -65,7 +65,7 @@ common ones include:
 \item Config/Needs/coverage for dependencies used in calculating test coverage.
 }}
 
-\item{upgrade}{One of "default", "ask", "always", or "never". "default"
+\item{upgrade}{Should package dependencies be upgraded? One of "default", "ask", "always", or "never". "default"
 respects the value of the \code{R_REMOTES_UPGRADE} environment variable if set,
 and falls back to "ask" if unset. "ask" prompts the user for which out of
 date packages to upgrade. For non-interactive sessions "ask" is equivalent

--- a/man/install_gitlab.Rd
+++ b/man/install_gitlab.Rd
@@ -55,7 +55,7 @@ common ones include:
 \item Config/Needs/coverage for dependencies used in calculating test coverage.
 }}
 
-\item{upgrade}{One of "default", "ask", "always", or "never". "default"
+\item{upgrade}{Should package dependencies be upgraded? One of "default", "ask", "always", or "never". "default"
 respects the value of the \code{R_REMOTES_UPGRADE} environment variable if set,
 and falls back to "ask" if unset. "ask" prompts the user for which out of
 date packages to upgrade. For non-interactive sessions "ask" is equivalent

--- a/man/install_local.Rd
+++ b/man/install_local.Rd
@@ -44,7 +44,7 @@ common ones include:
 \item Config/Needs/coverage for dependencies used in calculating test coverage.
 }}
 
-\item{upgrade}{One of "default", "ask", "always", or "never". "default"
+\item{upgrade}{Should package dependencies be upgraded? One of "default", "ask", "always", or "never". "default"
 respects the value of the \code{R_REMOTES_UPGRADE} environment variable if set,
 and falls back to "ask" if unset. "ask" prompts the user for which out of
 date packages to upgrade. For non-interactive sessions "ask" is equivalent

--- a/man/install_remote.Rd
+++ b/man/install_remote.Rd
@@ -53,7 +53,7 @@ common ones include:
 \item Config/Needs/coverage for dependencies used in calculating test coverage.
 }}
 
-\item{upgrade}{One of "default", "ask", "always", or "never". "default"
+\item{upgrade}{Should package dependencies be upgraded? One of "default", "ask", "always", or "never". "default"
 respects the value of the \code{R_REMOTES_UPGRADE} environment variable if set,
 and falls back to "ask" if unset. "ask" prompts the user for which out of
 date packages to upgrade. For non-interactive sessions "ask" is equivalent

--- a/man/install_svn.Rd
+++ b/man/install_svn.Rd
@@ -52,7 +52,7 @@ common ones include:
 \item Config/Needs/coverage for dependencies used in calculating test coverage.
 }}
 
-\item{upgrade}{One of "default", "ask", "always", or "never". "default"
+\item{upgrade}{Should package dependencies be upgraded? One of "default", "ask", "always", or "never". "default"
 respects the value of the \code{R_REMOTES_UPGRADE} environment variable if set,
 and falls back to "ask" if unset. "ask" prompts the user for which out of
 date packages to upgrade. For non-interactive sessions "ask" is equivalent

--- a/man/install_url.Rd
+++ b/man/install_url.Rd
@@ -44,7 +44,7 @@ common ones include:
 \item Config/Needs/coverage for dependencies used in calculating test coverage.
 }}
 
-\item{upgrade}{One of "default", "ask", "always", or "never". "default"
+\item{upgrade}{Should package dependencies be upgraded? One of "default", "ask", "always", or "never". "default"
 respects the value of the \code{R_REMOTES_UPGRADE} environment variable if set,
 and falls back to "ask" if unset. "ask" prompts the user for which out of
 date packages to upgrade. For non-interactive sessions "ask" is equivalent

--- a/man/install_version.Rd
+++ b/man/install_version.Rd
@@ -58,7 +58,7 @@ in package dependencies. One of the following formats:
     In all of these, \code{"LinkingTo"} is omitted for binary packages.
   }
 
-\item{upgrade}{One of "default", "ask", "always", or "never". "default"
+\item{upgrade}{Should package dependencies be upgraded? One of "default", "ask", "always", or "never". "default"
 respects the value of the \code{R_REMOTES_UPGRADE} environment variable if set,
 and falls back to "ask" if unset. "ask" prompts the user for which out of
 date packages to upgrade. For non-interactive sessions "ask" is equivalent

--- a/man/package_deps.Rd
+++ b/man/package_deps.Rd
@@ -67,7 +67,7 @@ common ones include:
 
 \item{object}{A \code{package_deps} object.}
 
-\item{upgrade}{One of "default", "ask", "always", or "never". "default"
+\item{upgrade}{Should package dependencies be upgraded? One of "default", "ask", "always", or "never". "default"
 respects the value of the \code{R_REMOTES_UPGRADE} environment variable if set,
 and falls back to "ask" if unset. "ask" prompts the user for which out of
 date packages to upgrade. For non-interactive sessions "ask" is equivalent

--- a/man/update_packages.Rd
+++ b/man/update_packages.Rd
@@ -40,7 +40,7 @@ common ones include:
 \item Config/Needs/coverage for dependencies used in calculating test coverage.
 }}
 
-\item{upgrade}{One of "default", "ask", "always", or "never". "default"
+\item{upgrade}{Should package dependencies be upgraded? One of "default", "ask", "always", or "never". "default"
 respects the value of the \code{R_REMOTES_UPGRADE} environment variable if set,
 and falls back to "ask" if unset. "ask" prompts the user for which out of
 date packages to upgrade. For non-interactive sessions "ask" is equivalent


### PR DESCRIPTION
This PR addresses the fact that the current documentation is a bit unclear when checking [`?install_github`](https://remotes.r-lib.org/reference/install_github.html). It is self-explanatory in the context of `package_deps()` but not so much in functions that inherit from it.

Please let me know if you'd like me to rewrap the source file and roxygenise. I didn't do it to keep my changes clear.