### PR TITLE
Support name + version as os argument

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * `system_requirements()` now supports querying released packages as well as development dependencies (#545)
 
+* `system_requirements()` now supports OS name + version in the `os` argument (#549, @krlmlr).
+
 # remotes 2.2.0
 
 ##  New functions and features

--- a/R/system_requirements.R
+++ b/R/system_requirements.R
@@ -19,13 +19,13 @@ DEFAULT_RSPM <-  "https://packagemanager.rstudio.com"
 #' @export
 system_requirements <- function(os, os_release = NULL, path = ".", package = NULL, curl = Sys.which("curl")) {
   if (is.null(os_release)) {
-    rx <- "^([^-]+)-([^-]+)$"
-    if (!grepl(rx, os)) {
+    os_release <- strsplit(os_release, "-", fixed = TRUE)[[1]]
+    if (length(os_release) != 2) {
       stop("If os_release is missing, os must consist of name and release.", call. = FALSE)
     }
 
-    os_release <- gsub(rx, "\\2", os)
-    os <- gsub(rx, "\\1", os)
+    os <- os_release[[1]]
+    os_release <- os_release[[2]]
   }
 
   os_versions <- supported_os_versions()

--- a/R/system_requirements.R
+++ b/R/system_requirements.R
@@ -9,12 +9,25 @@ DEFAULT_RSPM <-  "https://packagemanager.rstudio.com"
 #' @param os,os_release The operating system and operating system release version, see
 #'   <https://github.com/rstudio/r-system-requirements#operating-systems> for the
 #'   list of supported operating systems.
+#'
+#'   If `os_release` is `NULL`, `os` must consist of the operating system
+#'   and the version separated by a dash, e.g. `"ubuntu-18.04"`.
 #' @param path The path to the dev package's root directory.
 #' @param package A CRAN package name. If not `NULL`, this is used and `path` is ignored.
 #' @param curl The location of the curl binary on your system.
 #' @return A character vector of commands needed to install the system requirements for the package.
 #' @export
-system_requirements <- function(os, os_release, path = ".", package = NULL, curl = Sys.which("curl")) {
+system_requirements <- function(os, os_release = NULL, path = ".", package = NULL, curl = Sys.which("curl")) {
+  if (is.null(os_release)) {
+    rx <- "^([^-]+)-([^-]+)$"
+    if (!grepl(rx, os)) {
+      stop("If os_release is missing, os must consist of name and release.", call. = FALSE)
+    }
+
+    os_release <- gsub(rx, "\\2", os)
+    os <- gsub(rx, "\\1", os)
+  }
+
   os_versions <- supported_os_versions()
 
   os <- match.arg(os, names(os_versions))

--- a/inst/install-github.R
+++ b/inst/install-github.R
@@ -556,7 +556,7 @@ function(...) {
   #'   - Config/Needs/website - for dependencies used in building the pkgdown site.
   #'   - Config/Needs/coverage for dependencies used in calculating test coverage.
   #' @param quiet If `TRUE`, suppress output.
-  #' @param upgrade One of "default", "ask", "always", or "never". "default"
+  #' @param upgrade Should package dependencies be upgraded? One of "default", "ask", "always", or "never". "default"
   #'   respects the value of the `R_REMOTES_UPGRADE` environment variable if set,
   #'   and falls back to "ask" if unset. "ask" prompts the user for which out of
   #'   date packages to upgrade. For non-interactive sessions "ask" is equivalent
@@ -4959,12 +4959,25 @@ function(...) {
   #' @param os,os_release The operating system and operating system release version, see
   #'   <https://github.com/rstudio/r-system-requirements#operating-systems> for the
   #'   list of supported operating systems.
+  #'
+  #'   If `os_release` is `NULL`, `os` must consist of the operating system
+  #'   and the version separated by a dash, e.g. `"ubuntu-18.04"`.
   #' @param path The path to the dev package's root directory.
   #' @param package A CRAN package name. If not `NULL`, this is used and `path` is ignored.
   #' @param curl The location of the curl binary on your system.
   #' @return A character vector of commands needed to install the system requirements for the package.
   #' @export
-  system_requirements <- function(os, os_release, path = ".", package = NULL, curl = Sys.which("curl")) {
+  system_requirements <- function(os, os_release = NULL, path = ".", package = NULL, curl = Sys.which("curl")) {
+    if (is.null(os_release)) {
+      os_release <- strsplit(os_release, "-", fixed = TRUE)[[1]]
+      if (length(os_release) != 2) {
+        stop("If os_release is missing, os must consist of name and release.", call. = FALSE)
+      }
+  
+      os <- os_release[[1]]
+      os_release <- os_release[[2]]
+    }
+  
     os_versions <- supported_os_versions()
   
     os <- match.arg(os, names(os_versions))

--- a/install-github.R
+++ b/install-github.R
@@ -556,7 +556,7 @@ function(...) {
   #'   - Config/Needs/website - for dependencies used in building the pkgdown site.
   #'   - Config/Needs/coverage for dependencies used in calculating test coverage.
   #' @param quiet If `TRUE`, suppress output.
-  #' @param upgrade One of "default", "ask", "always", or "never". "default"
+  #' @param upgrade Should package dependencies be upgraded? One of "default", "ask", "always", or "never". "default"
   #'   respects the value of the `R_REMOTES_UPGRADE` environment variable if set,
   #'   and falls back to "ask" if unset. "ask" prompts the user for which out of
   #'   date packages to upgrade. For non-interactive sessions "ask" is equivalent
@@ -4959,12 +4959,25 @@ function(...) {
   #' @param os,os_release The operating system and operating system release version, see
   #'   <https://github.com/rstudio/r-system-requirements#operating-systems> for the
   #'   list of supported operating systems.
+  #'
+  #'   If `os_release` is `NULL`, `os` must consist of the operating system
+  #'   and the version separated by a dash, e.g. `"ubuntu-18.04"`.
   #' @param path The path to the dev package's root directory.
   #' @param package A CRAN package name. If not `NULL`, this is used and `path` is ignored.
   #' @param curl The location of the curl binary on your system.
   #' @return A character vector of commands needed to install the system requirements for the package.
   #' @export
-  system_requirements <- function(os, os_release, path = ".", package = NULL, curl = Sys.which("curl")) {
+  system_requirements <- function(os, os_release = NULL, path = ".", package = NULL, curl = Sys.which("curl")) {
+    if (is.null(os_release)) {
+      os_release <- strsplit(os_release, "-", fixed = TRUE)[[1]]
+      if (length(os_release) != 2) {
+        stop("If os_release is missing, os must consist of name and release.", call. = FALSE)
+      }
+  
+      os <- os_release[[1]]
+      os_release <- os_release[[2]]
+    }
+  
     os_versions <- supported_os_versions()
   
     os <- match.arg(os, names(os_versions))

--- a/man/system_requirements.Rd
+++ b/man/system_requirements.Rd
@@ -6,7 +6,7 @@
 \usage{
 system_requirements(
   os,
-  os_release,
+  os_release = NULL,
   path = ".",
   package = NULL,
   curl = Sys.which("curl")
@@ -15,7 +15,10 @@ system_requirements(
 \arguments{
 \item{os, os_release}{The operating system and operating system release version, see
 \url{https://github.com/rstudio/r-system-requirements#operating-systems} for the
-list of supported operating systems.}
+list of supported operating systems.
+
+If \code{os_release} is \code{NULL}, \code{os} must consist of the operating system
+and the version separated by a dash, e.g. \code{"ubuntu-18.04"}.}
 
 \item{path}{The path to the dev package's root directory.}
 


### PR DESCRIPTION
to `system_requirements()` . This allows using `os = "${{ matrix.config.os }}"` in GitHub Actions.