### PR TITLE
Use webfakes for download tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,6 +37,7 @@ Suggests:
     rmarkdown,
     rprojroot,
     testthat,
+    webfakes,
     withr
 Depends:
     R (>= 3.0.0)

--- a/R/download.R
+++ b/R/download.R
@@ -109,7 +109,7 @@ base_download_curl <- function(url, path, quiet, headers) {
 
   # always add `-L`, so that curl follows redirects. GitHub in particular uses
   # 302 redirects extensively, so without -L these requests fail.
-  extra <- c(extra, "-L")
+  extra <- c(extra, "--fail", "-L")
 
   if (length(headers)) {
     qh <- shQuote(paste0(names(headers), ": ", headers))

--- a/inst/install-github.R
+++ b/inst/install-github.R
@@ -1424,7 +1424,7 @@ function(...) {
   
     # always add `-L`, so that curl follows redirects. GitHub in particular uses
     # 302 redirects extensively, so without -L these requests fail.
-    extra <- c(extra, "-L")
+    extra <- c(extra, "--fail", "-L")
   
     if (length(headers)) {
       qh <- shQuote(paste0(names(headers), ": ", headers))

--- a/install-github.R
+++ b/install-github.R
@@ -1424,7 +1424,7 @@ function(...) {
   
     # always add `-L`, so that curl follows redirects. GitHub in particular uses
     # 302 redirects extensively, so without -L these requests fail.
-    extra <- c(extra, "-L")
+    extra <- c(extra, "--fail", "-L")
   
     if (length(headers)) {
       qh <- shQuote(paste0(names(headers), ": ", headers))

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -56,3 +56,5 @@ test_temp_dir <- function(pattern = "test-dir-", envir = parent.frame()) {
   dir.create(tmp, recursive = TRUE, showWarnings = FALSE)
   tmp
 }
+
+httpbin <- webfakes::new_app_process(webfakes::httpbin_app())

--- a/tests/testthat/test-download.R
+++ b/tests/testthat/test-download.R
@@ -28,17 +28,14 @@ test_that("download_method", {
 
 test_that("download", {
 
-  skip_on_cran()
-  skip_if_offline()
-
   tmp <- tempfile()
   on.exit(unlink(tmp), add = TRUE)
 
-  download(tmp, "http://httpbin.org/get", auth_token = NULL)
+  download(tmp, httpbin$url("/get"), auth_token = NULL)
   res <- json$parse_file(tmp)
   expect_null(res$headers$Authorization)
 
-  download(tmp, "http://httpbin.org/get", auth_token = "foobar")
+  download(tmp, httpbin$url("/get"), auth_token = "foobar")
   res <- json$parse_file(tmp)
   expect_equal(res$headers$Authorization, "token foobar")
 
@@ -50,54 +47,43 @@ test_that("os_type", {
 })
 
 test_that("download fallback to curl, https", {
-
-  skip_on_cran()
-  skip_if_offline()
   skip_if(is_standalone())
 
   mockery::stub(download, "get_r_version", "3.0.0")
-  download(tmp <- tempfile(), "https://httpbin.org/ip")
-  expect_match(paste(readLines(tmp), collapse = "\n"), "origin")
+  download(tmp <- tempfile(), httpbin$url("/ip"))
+  expect_match(paste(readLines(tmp, warn = FALSE), collapse = "\n"), "origin")
 })
 
 test_that("download with curl, basic auth", {
-
-  skip_on_cran()
-  skip_if_offline()
   skip_if(is_standalone())
 
   mockery::stub(download, "get_r_version", "3.0.0")
   download(
     tmp <- tempfile(),
-    "http://httpbin.org/basic-auth/user/passwd",
+    httpbin$url("/basic-auth/user/passwd"),
     basic_auth = list(user = "user", password = "passwd")
   )
   expect_match(
-    paste(readLines(tmp), collapse = "\n"),
-    '"authenticated": true'
+    paste(readLines(tmp, warn = FALSE), collapse = "\n"),
+    '"authenticated":true'
   )
 })
 
 test_that("base download with custom headers", {
-  skip_on_cran()
-  skip_if_offline()
-
-  url <- "http://httpbin.org/anything"
+  url <- httpbin$url("/anything")
   tmp <- tempfile()
   on.exit(unlink(tmp), add = TRUE)
   head <- c("X-Custom" = "Foobar")
   base_download(url, path = tmp, quiet = TRUE, headers = head)
   expect_true(file.exists(tmp))
-  resp <- json$parse(readLines(tmp))
+  resp <- json$parse(readLines(tmp, warn = FALSE))
   expect_equal(resp$headers$`X-Custom`, "Foobar")
 })
 
 test_that("wget method download with custom headers", {
-  skip_on_cran()
-  skip_if_offline()
   skip_without_program("wget")
 
-  url <- "http://httpbin.org/anything"
+  url <- httpbin$url("/anything")
   tmp <- tempfile()
   on.exit(unlink(tmp), add = TRUE)
   head <- c("X-Custom" = "Foobar")
@@ -106,17 +92,15 @@ test_that("wget method download with custom headers", {
     list(download.file.method = "wget", download.file.extra = extra),
     base_download(url, path = tmp, quiet = TRUE, headers = head))
   expect_true(file.exists(tmp))
-  resp <- json$parse(readLines(tmp))
+  resp <- json$parse(readLines(tmp, warn = FALSE))
   expect_equal(resp$headers$`X-Custom`, "Foobar")
   expect_equal(resp$headers$`X-Another`, "extra-header")
 })
 
 test_that("curl method download with custom headers", {
-  skip_on_cran()
-  skip_if_offline()
   skip_without_program("curl")
 
-  url <- "http://httpbin.org/anything"
+  url <- httpbin$url("/anything")
   tmp <- tempfile()
   on.exit(unlink(tmp), add = TRUE)
   head <- c("X-Custom" = "Foobar")
@@ -125,16 +109,13 @@ test_that("curl method download with custom headers", {
     list(download.file.method = "curl", download.file.extra = extra),
     base_download(url, path = tmp, quiet = TRUE, headers = head))
   expect_true(file.exists(tmp))
-  resp <- json$parse(readLines(tmp))
+  resp <- json$parse(readLines(tmp, warn = FALSE))
   expect_equal(resp$headers$`X-Custom`, "Foobar")
   expect_equal(resp$headers$`X-Another`, "extra-header")
 })
 
 test_that("internal method download with custom headers", {
-  skip_on_cran()
-  skip_if_offline()
-
-  url <- "http://httpbin.org/anything"
+  url <- httpbin$url("/anything")
   tmp <- tempfile()
   on.exit(unlink(tmp), add = TRUE)
   head <- c("X-Custom" = "Foobar")
@@ -142,17 +123,15 @@ test_that("internal method download with custom headers", {
     list(download.file.method = "internal"),
     base_download(url, path = tmp, quiet = TRUE, headers = head))
   expect_true(file.exists(tmp))
-  resp <- json$parse(readLines(tmp))
+  resp <- json$parse(readLines(tmp, warn = FALSE))
   expect_equal(resp$headers$`X-Custom`, "Foobar")
 })
 
 test_that("wininet method download with custom headers", {
-  skip_on_cran()
-  skip_if_offline()
   if (os_type() == "unix") return(expect_true(TRUE))
   if (getRversion() < "3.6.0") return(expect_true(TRUE))
 
-  url <- "http://httpbin.org/anything"
+  url <- httpbin$url("/anything")
   tmp <- tempfile()
   on.exit(unlink(tmp), add = TRUE)
   head <- c("X-Custom" = "Foobar")
@@ -160,45 +139,37 @@ test_that("wininet method download with custom headers", {
     list(download.file.method = "wininet"),
     base_download(url, path = tmp, quiet = TRUE, headers = head))
   expect_true(file.exists(tmp))
-  resp <- json$parse(readLines(tmp))
+  resp <- json$parse(readLines(tmp, warn = FALSE))
   expect_equal(resp$headers$`X-Custom`, "Foobar")
 })
 
 test_that("curl download with custom headers", {
-  skip_on_cran()
-  skip_if_offline()
-
-  url <- "https://httpbin.org/anything"
+  url <- httpbin$url("/anything")
   tmp <- tempfile()
   on.exit(unlink(tmp), add = TRUE)
   head <- c("X-Custom" = "Foobar")
   curl_download(url, path = tmp, quiet = TRUE, headers = head)
   expect_true(file.exists(tmp))
-  resp <- json$parse(readLines(tmp))
+  resp <- json$parse(readLines(tmp, warn = FALSE))
   expect_equal(resp$headers$`X-Custom`, "Foobar")
 })
 
 test_that("base download with basic auth", {
-  skip_on_cran()
-  skip_if_offline()
-
-  url <- "http://httpbin.org/basic-auth/ruser/rpass"
+  url <- httpbin$url("/basic-auth/ruser/rpass")
   tmp <- tempfile()
   on.exit(unlink(tmp), add = TRUE)
   download(url, path = tmp, quiet = TRUE,
            basic_auth = list(user = "ruser", password = "rpass"))
   expect_true(file.exists(tmp))
-  resp <- json$parse(readLines(tmp))
+  resp <- json$parse(readLines(tmp, warn = FALSE))
   expect_true(resp$authenticated)
   expect_equal(resp$user, "ruser")
 })
 
 test_that("base wget download with basic auth", {
-  skip_on_cran()
-  skip_if_offline()
   skip_without_program("wget")
 
-  url <- "http://httpbin.org/basic-auth/ruser/rpass"
+  url <- httpbin$url("/basic-auth/ruser/rpass")
   tmp <- tempfile()
   on.exit(unlink(tmp), add = TRUE)
   with_options(
@@ -206,17 +177,15 @@ test_that("base wget download with basic auth", {
          download(url, path = tmp, quiet = TRUE,
                   basic_auth = list(user = "ruser", password = "rpass")))
   expect_true(file.exists(tmp))
-  resp <- json$parse(readLines(tmp))
+  resp <- json$parse(readLines(tmp, warn = FALSE))
   expect_true(resp$authenticated)
   expect_equal(resp$user, "ruser")
 })
 
 test_that("base curl download with basic auth", {
-  skip_on_cran()
-  skip_if_offline()
   skip_without_program("curl")
 
-  url <- "http://httpbin.org/basic-auth/ruser/rpass"
+  url <- httpbin$url("/basic-auth/ruser/rpass")
   tmp <- tempfile()
   on.exit(unlink(tmp), add = TRUE)
   with_options(
@@ -224,16 +193,13 @@ test_that("base curl download with basic auth", {
          download(url, path = tmp, quiet = TRUE,
                   basic_auth = list(user = "ruser", password = "rpass")))
   expect_true(file.exists(tmp))
-  resp <- json$parse(readLines(tmp))
+  resp <- json$parse(readLines(tmp, warn = FALSE))
   expect_true(resp$authenticated)
   expect_equal(resp$user, "ruser")
 })
 
 test_that("base internal download with basic auth", {
-  skip_on_cran()
-  skip_if_offline()
-
-  url <- "http://httpbin.org/basic-auth/ruser/rpass"
+  url <- httpbin$url("/basic-auth/ruser/rpass")
   tmp <- tempfile()
   on.exit(unlink(tmp), add = TRUE)
   with_options(
@@ -241,18 +207,16 @@ test_that("base internal download with basic auth", {
          download(url, path = tmp, quiet = TRUE,
                   basic_auth = list(user = "ruser", password = "rpass")))
   expect_true(file.exists(tmp))
-  resp <- json$parse(readLines(tmp))
+  resp <- json$parse(readLines(tmp, warn = FALSE))
   expect_true(resp$authenticated)
   expect_equal(resp$user, "ruser")
 })
 
 test_that("base wininet download with basic auth", {
-  skip_on_cran()
-  skip_if_offline()
   if (os_type() == "unix") return(expect_true(TRUE))
   if (getRversion() < "3.6.0") return(expect_true(TRUE))
 
-  url <- "http://httpbin.org/basic-auth/ruser/rpass"
+  url <- httpbin$url("/basic-auth/ruser/rpass")
   tmp <- tempfile()
   on.exit(unlink(tmp), add = TRUE)
   with_options(
@@ -260,35 +224,29 @@ test_that("base wininet download with basic auth", {
          download(url, path = tmp, quiet = TRUE,
                   basic_auth = list(user = "ruser", password = "rpass")))
   expect_true(file.exists(tmp))
-  resp <- json$parse(readLines(tmp))
+  resp <- json$parse(readLines(tmp, warn = FALSE))
   expect_true(resp$authenticated)
   expect_equal(resp$user, "ruser")
 })
 
 test_that("curl download with basic auth", {
-  skip_on_cran()
-  skip_if_offline()
-
   mockery::stub(download, "get_r_version", "3.0.0")
 
-  url <- "https://httpbin.org/basic-auth/ruser/rpass"
+  url <- httpbin$url("/basic-auth/ruser/rpass")
   tmp <- tempfile()
   on.exit(unlink(tmp), add = TRUE)
   download(url, path = tmp, quiet = TRUE,
            basic_auth = list(user = "ruser", password = "rpass"))
   expect_true(file.exists(tmp))
-  resp <- json$parse(readLines(tmp))
+  resp <- json$parse(readLines(tmp, warn = FALSE))
   expect_true(resp$authenticated)
   expect_equal(resp$user, "ruser")
 })
 
 test_that("base curl download redirects", {
-  skip("redirect endpoint not working")
-  skip_on_cran()
-  skip_if_offline()
   skip_without_program("curl")
 
-  url <- "http://httpbin.org/absolute-redirect/1"
+  url <- httpbin$url("/absolute-redirect/1")
   tmp <- tempfile()
   on.exit(unlink(tmp), add = TRUE)
   with_options(
@@ -296,6 +254,6 @@ test_that("base curl download redirects", {
          download(url, path = tmp, quiet = TRUE)
   )
   expect_true(file.exists(tmp))
-  resp <- json$parse(readLines(tmp))
-  expect_equal(resp$url, "http://httpbin.org/get")
+  resp <- json$parse(readLines(tmp, warn = FALSE))
+  expect_equal(resp$url, httpbin$url("/get"))
 })

--- a/tests/testthat/test-download.R
+++ b/tests/testthat/test-download.R
@@ -49,7 +49,7 @@ test_that("os_type", {
 test_that("download fallback to curl, https", {
   skip_if(is_standalone())
 
-  mockery::stub(download, "get_r_version", "3.0.0")
+  mockery::stub(download, "getRversion", package_version("3.0.0"))
   download(tmp <- tempfile(), httpbin$url("/ip"))
   expect_match(paste(readLines(tmp, warn = FALSE), collapse = "\n"), "origin")
 })
@@ -57,7 +57,7 @@ test_that("download fallback to curl, https", {
 test_that("download with curl, basic auth", {
   skip_if(is_standalone())
 
-  mockery::stub(download, "get_r_version", "3.0.0")
+  mockery::stub(download, "getRversion", package_version("3.0.0"))
   download(
     tmp <- tempfile(),
     httpbin$url("/basic-auth/user/passwd"),
@@ -230,7 +230,7 @@ test_that("base wininet download with basic auth", {
 })
 
 test_that("curl download with basic auth", {
-  mockery::stub(download, "get_r_version", "3.0.0")
+  mockery::stub(download, "getRversion", package_version("3.0.0"))
 
   url <- httpbin$url("/basic-auth/ruser/rpass")
   tmp <- tempfile()


### PR DESCRIPTION
Plus: 
* Add `--fail` to external curl downloads, so that curl exits with a non-zero exit code for HTTP failures.
* Remove some unused download helper functions.
* Add some extra tests.
