### PR TITLE
Support option() to specify Bioc_git_branch

### DIFF
--- a/R/install-bioc.R
+++ b/R/install-bioc.R
@@ -254,7 +254,7 @@ bioconductor_branch <- function(release, sha) {
     sha
   } else {
     if (is.null(release)) {
-      release <- "release"
+      release <- getOption("Bioc_git_branch", "release")
     }
     if (release == "release") {
       release <- bioconductor_release()


### PR DESCRIPTION
See issue #578 . The rationale is that while R_BIOC_VERSION can specify the R version, this does not link to selecting the git branch. This proposal adds support for the option 'Bioc_git_branch', to let the developer specify this separately.