### PR TITLE
Switch branch detection to respect R_BIOC_VERSION

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 * `system_requirements()` now supports OS name + version in the `os` argument (#549, @krlmlr).
 
+* `install_bioc()` now respects the environment variable R_BIOC_VERSION, and will use the git branch corresponding to this Bioconductor version (#580).
+
 # remotes 2.2.0
 
 ##  New functions and features

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
 
 * `system_requirements()` now supports OS name + version in the `os` argument (#549, @krlmlr).
 
-* `install_bioc()` now respects the environment variable R_BIOC_VERSION, and will use the git branch corresponding to this Bioconductor version (#580).
+* `install_bioc()` now respects the environment variable R_BIOC_VERSION, and will use the git branch corresponding to this Bioconductor version (@bbimber, #580).
 
 # remotes 2.2.0
 

--- a/R/install-bioc.R
+++ b/R/install-bioc.R
@@ -254,7 +254,7 @@ bioconductor_branch <- function(release, sha) {
     sha
   } else {
     if (is.null(release)) {
-      release <- ifelse(Sys.getenv("R_BIOC_VERSION") != "", yes = Sys.getenv("R_BIOC_VERSION"), no = "release")
+      release <- Sys.getenv("R_BIOC_VERSION", "release")
     }
     if (release == "release") {
       release <- bioconductor_release()

--- a/R/install-bioc.R
+++ b/R/install-bioc.R
@@ -259,7 +259,7 @@ bioconductor_branch <- function(release, sha) {
     if (release == "release") {
       release <- bioconductor_release()
     } else if (release == bioconductor$get_devel_version()) {
-      release = "devel"
+      release <- "devel"
     }
     switch(
       tolower(release),
@@ -301,4 +301,3 @@ git_repo_sha1 <- function(r) {
     git2r::branch_target(rev)
   }
 }
-

--- a/R/install-bioc.R
+++ b/R/install-bioc.R
@@ -254,10 +254,12 @@ bioconductor_branch <- function(release, sha) {
     sha
   } else {
     if (is.null(release)) {
-      release <- "release"
+      release <- ifelse(Sys.getenv("R_BIOC_VERSION") != "", yes = Sys.getenv("R_BIOC_VERSION"), no = "release")
     }
     if (release == "release") {
       release <- bioconductor_release()
+    } else if (release == bioconductor$get_devel_version()) {
+      release = "devel"
     }
     switch(
       tolower(release),


### PR DESCRIPTION
@jimhester Thanks for replying on the issue. My original idea here involved making a redundant option() to hold the git branch used when querying bioconductor. This updated PR simply uses the already supported R_BIOC_VERSION environment variable, and ensures that when querying git we use a branch that respects that setting.

There seem to be tests that need updating, which i would do if this is something you'd consider. 

The remotes/bioconductor configuration is complex and maybe I'm missing something. However, if R_BIOC_VERSION is supposed to force remotes to use a specific version it seems like it should be respected on this codepath too. 