### PR TITLE
Fix HTTP(S) git repo installation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Re-license as MIT. (#551)
 
+* `remote_package_name.git2r_remote` and `remote_package_name.xgit_remote` now get correct package name from HTTP(S) git repo's `DESCRIPTION` file, and thus package's `DESCRIPTION` file's `Remotes` field could have `git::http(s)://<host>/<username>/<repo>[.git][@ref]` items that install remote packages using git via HTTP(S) protocal (@niheaven, #603).
+
 # remotes 2.3.0
 
 ## Major changes
@@ -75,8 +77,8 @@
   field. In such a case, the values for `getOption("repos")` and
   `getOption("pkgType")` will be used (respectively).
 
-* `install_gitlab()` now installs from repositories in subgroups and with dots 
-  in their name. `subdir` is now an explicit argument instead of implicit in 
+* `install_gitlab()` now installs from repositories in subgroups and with dots
+  in their name. `subdir` is now an explicit argument instead of implicit in
   `repo` (@robertdj, #259, #420).
 
 * `install()` now passes the ellipsis `...` to `install_deps()` (@Neil-Schneider, #411)

--- a/inst/install-github.R
+++ b/inst/install-github.R
@@ -2613,8 +2613,8 @@ function(...) {
   #' @export
   #' @examples
   #' \dontrun{
-  #' install_git("git://github.com/hadley/stringr.git")
-  #' install_git("git://github.com/hadley/stringr.git", ref = "stringr-0.2")
+  #' install_git("https://github.com/hadley/stringr.git")
+  #' install_git("https://github.com/hadley/stringr.git", ref = "stringr-0.2")
   #' }
   install_git <- function(url, subdir = NULL, ref = NULL, branch = NULL,
                           credentials = git_credentials(),

--- a/inst/install-github.R
+++ b/inst/install-github.R
@@ -2615,7 +2615,7 @@ function(...) {
   #' \dontrun{
   #' install_git("git://github.com/hadley/stringr.git")
   #' install_git("git://github.com/hadley/stringr.git", ref = "stringr-0.2")
-  #'}
+  #' }
   install_git <- function(url, subdir = NULL, ref = NULL, branch = NULL,
                           credentials = git_credentials(),
                           git = c("auto", "git2r", "external"),
@@ -2628,33 +2628,35 @@ function(...) {
                           repos = getOption("repos"),
                           type = getOption("pkgType"),
                           ...) {
-  
     if (!missing(branch)) {
       warning("`branch` is deprecated, please use `ref`")
       ref <- branch
     }
   
-    remotes <- lapply(url, git_remote, subdir = subdir, ref = ref,
-      credentials = credentials, git = match.arg(git))
+    remotes <- lapply(url, git_remote,
+      subdir = subdir, ref = ref,
+      credentials = credentials, git = match.arg(git)
+    )
   
-    install_remotes(remotes, credentials = credentials,
-                    dependencies = dependencies,
-                    upgrade = upgrade,
-                    force = force,
-                    quiet = quiet,
-                    build = build,
-                    build_opts = build_opts,
-                    build_manual = build_manual,
-                    build_vignettes = build_vignettes,
-                    repos = repos,
-                    type = type,
-                    ...)
+    install_remotes(remotes,
+      credentials = credentials,
+      dependencies = dependencies,
+      upgrade = upgrade,
+      force = force,
+      quiet = quiet,
+      build = build,
+      build_opts = build_opts,
+      build_manual = build_manual,
+      build_vignettes = build_vignettes,
+      repos = repos,
+      type = type,
+      ...
+    )
   }
   
   
   git_remote <- function(url, subdir = NULL, ref = NULL, credentials = git_credentials(),
                          git = c("auto", "git2r", "external"), ...) {
-  
     git <- match.arg(git)
     if (git == "auto") {
       git <- if (!is_standalone() && pkg_installed("git2r")) "git2r" else "external"
@@ -2664,7 +2666,10 @@ function(...) {
       stop("`credentials` can only be used with `git = \"git2r\"`", call. = FALSE)
     }
   
-    list(git2r = git_remote_git2r, external = git_remote_xgit)[[git]](url, subdir, ref, credentials)
+    meta <- re_match(url, "(?:(?<url>[^@]*))(?:@(?<ref>.*))?")
+    ref <- ref %||% (if (meta$ref == "") NULL else meta$ref)
+  
+    list(git2r = git_remote_git2r, external = git_remote_xgit)[[git]](meta$url, subdir, ref, credentials)
   }
   
   
@@ -2723,49 +2728,65 @@ function(...) {
   
   #' @export
   remote_package_name.git2r_remote <- function(remote, ...) {
-  
     tmp <- tempfile()
     on.exit(unlink(tmp))
     description_path <- paste0(collapse = "/", c(remote$subdir, "DESCRIPTION"))
   
-    # Try using git archive --remote to retrieve the DESCRIPTION, if the protocol
-    # or server doesn't support that return NA
-    res <- try(silent = TRUE,
-      system_check(git_path(),
-        args = c("archive", "-o", tmp, "--remote", remote$url,
-          if (is.null(remote$ref)) "HEAD" else remote$ref,
-          description_path),
-        quiet = TRUE))
+    if (grepl("^https?://", remote$url)) {
+      url <- build_url(sub("\\.git$", "", remote$url), "raw", remote_sha(remote, ...), description_path)
+      download(tmp, url)
+      read_dcf(tmp)$Package
+    } else {
+      # Try using git archive --remote to retrieve the DESCRIPTION, if the protocol
+      # or server doesn't support that return NA
+      res <- try(
+        silent = TRUE,
+        system_check(git_path(),
+          args = c(
+            "archive", "-o", tmp, "--remote", remote$url,
+            if (is.null(remote$ref)) "HEAD" else remote$ref,
+            description_path
+          ),
+          quiet = TRUE
+        )
+      )
   
-    if (inherits(res, "try-error")) {
-      return(NA_character_)
+      if (inherits(res, "try-error")) {
+        return(NA_character_)
+      }
+  
+      # git archive returns a tar file, so extract it to tempdir and read the DCF
+      utils::untar(tmp, files = description_path, exdir = tempdir())
+  
+      read_dcf(file.path(tempdir(), description_path))$Package
     }
-  
-    # git archive returns a tar file, so extract it to tempdir and read the DCF
-    utils::untar(tmp, files = description_path, exdir = tempdir())
-  
-    read_dcf(file.path(tempdir(), description_path))$Package
   }
   
   #' @export
   remote_sha.git2r_remote <- function(remote, ...) {
-    tryCatch({
-      # set suppressWarnings in git2r 0.23.0+
-      res <- suppressWarnings(git2r::remote_ls(remote$url, credentials=remote$credentials))
+    tryCatch(
+      {
+        # set suppressWarnings in git2r 0.23.0+
+        res <- suppressWarnings(git2r::remote_ls(remote$url, credentials = remote$credentials))
   
-      ref <- remote$ref %||% "HEAD"
+        ref <- remote$ref %||% "HEAD"
   
-      if(ref != "HEAD") ref <- paste0("/",ref)
+        if (ref != "HEAD") ref <- paste0("/", ref)
   
-      found <- grep(pattern = paste0(ref,"$"), x = names(res))
+        found <- grep(pattern = paste0(ref, "$"), x = names(res))
   
-      # If none found, it is either a SHA, so return the pinned sha or NA
-      if (length(found) == 0) {
-        return(remote$ref %||% NA_character_)
+        # If none found, it is either a SHA, so return the pinned sha or NA
+        if (length(found) == 0) {
+          return(remote$ref %||% NA_character_)
+        }
+  
+        unname(res[found[1]])
+      },
+      error = function(e) {
+        warning(e)
+        NA_character_
       }
-  
-      unname(res[found[1]])
-    }, error = function(e) { warning(e);  NA_character_})
+    )
   }
   
   #' @export
@@ -2786,7 +2807,7 @@ function(...) {
   
     bundle <- tempfile()
   
-    args <- c('clone', '--depth', '1', '--no-hardlinks')
+    args <- c("clone", "--depth", "1", "--no-hardlinks")
     args <- c(args, x$args, x$url, bundle)
     git(paste0(args, collapse = " "), quiet = quiet)
   
@@ -2831,8 +2852,10 @@ function(...) {
       return(remote$ref %||% NA_character_)
     }
   
-    refs_df <- read.delim(text = refs, stringsAsFactors = FALSE, sep = "\t",
-      header = FALSE)
+    refs_df <- read.delim(
+      text = refs, stringsAsFactors = FALSE, sep = "\t",
+      header = FALSE
+    )
     names(refs_df) <- c("sha", "ref")
   
     refs_df$sha[[1]]

--- a/install-github.R
+++ b/install-github.R
@@ -2613,8 +2613,8 @@ function(...) {
   #' @export
   #' @examples
   #' \dontrun{
-  #' install_git("git://github.com/hadley/stringr.git")
-  #' install_git("git://github.com/hadley/stringr.git", ref = "stringr-0.2")
+  #' install_git("https://github.com/hadley/stringr.git")
+  #' install_git("https://github.com/hadley/stringr.git", ref = "stringr-0.2")
   #' }
   install_git <- function(url, subdir = NULL, ref = NULL, branch = NULL,
                           credentials = git_credentials(),

--- a/install-github.R
+++ b/install-github.R
@@ -2615,7 +2615,7 @@ function(...) {
   #' \dontrun{
   #' install_git("git://github.com/hadley/stringr.git")
   #' install_git("git://github.com/hadley/stringr.git", ref = "stringr-0.2")
-  #'}
+  #' }
   install_git <- function(url, subdir = NULL, ref = NULL, branch = NULL,
                           credentials = git_credentials(),
                           git = c("auto", "git2r", "external"),
@@ -2628,33 +2628,35 @@ function(...) {
                           repos = getOption("repos"),
                           type = getOption("pkgType"),
                           ...) {
-  
     if (!missing(branch)) {
       warning("`branch` is deprecated, please use `ref`")
       ref <- branch
     }
   
-    remotes <- lapply(url, git_remote, subdir = subdir, ref = ref,
-      credentials = credentials, git = match.arg(git))
+    remotes <- lapply(url, git_remote,
+      subdir = subdir, ref = ref,
+      credentials = credentials, git = match.arg(git)
+    )
   
-    install_remotes(remotes, credentials = credentials,
-                    dependencies = dependencies,
-                    upgrade = upgrade,
-                    force = force,
-                    quiet = quiet,
-                    build = build,
-                    build_opts = build_opts,
-                    build_manual = build_manual,
-                    build_vignettes = build_vignettes,
-                    repos = repos,
-                    type = type,
-                    ...)
+    install_remotes(remotes,
+      credentials = credentials,
+      dependencies = dependencies,
+      upgrade = upgrade,
+      force = force,
+      quiet = quiet,
+      build = build,
+      build_opts = build_opts,
+      build_manual = build_manual,
+      build_vignettes = build_vignettes,
+      repos = repos,
+      type = type,
+      ...
+    )
   }
   
   
   git_remote <- function(url, subdir = NULL, ref = NULL, credentials = git_credentials(),
                          git = c("auto", "git2r", "external"), ...) {
-  
     git <- match.arg(git)
     if (git == "auto") {
       git <- if (!is_standalone() && pkg_installed("git2r")) "git2r" else "external"
@@ -2664,7 +2666,10 @@ function(...) {
       stop("`credentials` can only be used with `git = \"git2r\"`", call. = FALSE)
     }
   
-    list(git2r = git_remote_git2r, external = git_remote_xgit)[[git]](url, subdir, ref, credentials)
+    meta <- re_match(url, "(?:(?<url>[^@]*))(?:@(?<ref>.*))?")
+    ref <- ref %||% (if (meta$ref == "") NULL else meta$ref)
+  
+    list(git2r = git_remote_git2r, external = git_remote_xgit)[[git]](meta$url, subdir, ref, credentials)
   }
   
   
@@ -2723,49 +2728,65 @@ function(...) {
   
   #' @export
   remote_package_name.git2r_remote <- function(remote, ...) {
-  
     tmp <- tempfile()
     on.exit(unlink(tmp))
     description_path <- paste0(collapse = "/", c(remote$subdir, "DESCRIPTION"))
   
-    # Try using git archive --remote to retrieve the DESCRIPTION, if the protocol
-    # or server doesn't support that return NA
-    res <- try(silent = TRUE,
-      system_check(git_path(),
-        args = c("archive", "-o", tmp, "--remote", remote$url,
-          if (is.null(remote$ref)) "HEAD" else remote$ref,
-          description_path),
-        quiet = TRUE))
+    if (grepl("^https?://", remote$url)) {
+      url <- build_url(sub("\\.git$", "", remote$url), "raw", remote_sha(remote, ...), description_path)
+      download(tmp, url)
+      read_dcf(tmp)$Package
+    } else {
+      # Try using git archive --remote to retrieve the DESCRIPTION, if the protocol
+      # or server doesn't support that return NA
+      res <- try(
+        silent = TRUE,
+        system_check(git_path(),
+          args = c(
+            "archive", "-o", tmp, "--remote", remote$url,
+            if (is.null(remote$ref)) "HEAD" else remote$ref,
+            description_path
+          ),
+          quiet = TRUE
+        )
+      )
   
-    if (inherits(res, "try-error")) {
-      return(NA_character_)
+      if (inherits(res, "try-error")) {
+        return(NA_character_)
+      }
+  
+      # git archive returns a tar file, so extract it to tempdir and read the DCF
+      utils::untar(tmp, files = description_path, exdir = tempdir())
+  
+      read_dcf(file.path(tempdir(), description_path))$Package
     }
-  
-    # git archive returns a tar file, so extract it to tempdir and read the DCF
-    utils::untar(tmp, files = description_path, exdir = tempdir())
-  
-    read_dcf(file.path(tempdir(), description_path))$Package
   }
   
   #' @export
   remote_sha.git2r_remote <- function(remote, ...) {
-    tryCatch({
-      # set suppressWarnings in git2r 0.23.0+
-      res <- suppressWarnings(git2r::remote_ls(remote$url, credentials=remote$credentials))
+    tryCatch(
+      {
+        # set suppressWarnings in git2r 0.23.0+
+        res <- suppressWarnings(git2r::remote_ls(remote$url, credentials = remote$credentials))
   
-      ref <- remote$ref %||% "HEAD"
+        ref <- remote$ref %||% "HEAD"
   
-      if(ref != "HEAD") ref <- paste0("/",ref)
+        if (ref != "HEAD") ref <- paste0("/", ref)
   
-      found <- grep(pattern = paste0(ref,"$"), x = names(res))
+        found <- grep(pattern = paste0(ref, "$"), x = names(res))
   
-      # If none found, it is either a SHA, so return the pinned sha or NA
-      if (length(found) == 0) {
-        return(remote$ref %||% NA_character_)
+        # If none found, it is either a SHA, so return the pinned sha or NA
+        if (length(found) == 0) {
+          return(remote$ref %||% NA_character_)
+        }
+  
+        unname(res[found[1]])
+      },
+      error = function(e) {
+        warning(e)
+        NA_character_
       }
-  
-      unname(res[found[1]])
-    }, error = function(e) { warning(e);  NA_character_})
+    )
   }
   
   #' @export
@@ -2786,7 +2807,7 @@ function(...) {
   
     bundle <- tempfile()
   
-    args <- c('clone', '--depth', '1', '--no-hardlinks')
+    args <- c("clone", "--depth", "1", "--no-hardlinks")
     args <- c(args, x$args, x$url, bundle)
     git(paste0(args, collapse = " "), quiet = quiet)
   
@@ -2831,8 +2852,10 @@ function(...) {
       return(remote$ref %||% NA_character_)
     }
   
-    refs_df <- read.delim(text = refs, stringsAsFactors = FALSE, sep = "\t",
-      header = FALSE)
+    refs_df <- read.delim(
+      text = refs, stringsAsFactors = FALSE, sep = "\t",
+      header = FALSE
+    )
     names(refs_df) <- c("sha", "ref")
   
     refs_df$sha[[1]]

--- a/man/install_git.Rd
+++ b/man/install_git.Rd
@@ -98,8 +98,8 @@ option.
 }
 \examples{
 \dontrun{
-install_git("git://github.com/hadley/stringr.git")
-install_git("git://github.com/hadley/stringr.git", ref = "stringr-0.2")
+install_git("https://github.com/hadley/stringr.git")
+install_git("https://github.com/hadley/stringr.git", ref = "stringr-0.2")
 }
 }
 \seealso{

--- a/tests/testthat/test-install-git.R
+++ b/tests/testthat/test-install-git.R
@@ -146,6 +146,48 @@ test_that("install_git with command line git and full SHA ref", {
   expect_true(!is.na(remote$sha) && nzchar(remote$sha))
 })
 
+test_that("remote_package_name.git2r_remote returns the package name if it exists", {
+  skip_on_cran()
+  skip_if_offline()
+  skip_if_not_installed("git2r")
+
+  # works without ref
+  url <- "https://github.com/cran/falsy.git"
+  remote <- git_remote(url, git = "git2r")
+  expect_equal(remote_package_name(remote), "falsy")
+
+  # works with SHAs in URL
+  url <- "https://github.com/igraph/rigraph.git@46bfafd"
+  remote <- git_remote(url, git = "git2r")
+  expect_equal(remote_package_name(remote), "igraph")
+
+  # works with tags in URL (and different name from repo name)
+  url <- "https://github.com/igraph/rigraph.git@master"
+  remote <- git_remote(url, git = "git2r")
+  expect_equal(remote_package_name(remote), "igraph")
+})
+
+test_that("remote_package_name.xgit_remote returns the package name if it exists", {
+  skip_on_cran()
+  skip_if_offline()
+  if (is.null(git_path())) skip("git is not installed")
+
+  # works without ref
+  url <- "https://github.com/cran/falsy.git"
+  remote <- git_remote(url, git = "external")
+  expect_equal(remote_package_name(remote), "falsy")
+
+  # works with SHAs in URL
+  url <- "https://github.com/igraph/rigraph.git@46bfafd"
+  remote <- git_remote(url, git = "external")
+  expect_equal(remote_package_name(remote), "igraph")
+
+  # works with tags in URL (and different name from repo name)
+  url <- "https://github.com/igraph/rigraph.git@master"
+  remote <- git_remote(url, git = "external")
+  expect_equal(remote_package_name(remote), "igraph")
+})
+
 test_that("remote_sha.xgit remote returns the SHA if it exists", {
   skip_on_cran()
   skip_if_offline()

--- a/vignettes/dependencies.Rmd
+++ b/vignettes/dependencies.Rmd
@@ -71,7 +71,8 @@ Also' section in `?install_github` for a complete list.
 Remotes: gitlab::jimhester/covr
 
 # Git
-Remotes: git::git@bitbucket.org:djnavarro/lsr.git
+Remotes: git::git@bitbucket.org:djnavarro/lsr.git,
+  git::https://github.com/igraph/rigraph.git@master
 
 # Bitbucket
 Remotes: bitbucket::sulab/mygene.r@default, djnavarro/lsr


### PR DESCRIPTION
- Fix #597 

Now for git repo, `remotes` use `git archive` to get `DESCRIPTION` file and package name (`remote_package_name.git2r_remote` and `remote_package_name.xgit_remote`). But for HTTP(S) protocol, `git archive` just say `fatal: operation not supported by protocol` and cannot work.

```fish
git archive --remote https://github.com/r-lib/httr.git
# fatal: operation not supported by protocol
```

This lead to some problem when users use HTTP(S) protocol with any git server, e.g. GitHub.com or private hosted server (Gogs, Gitea, etc.). Here is a example:

1. Just add following lines in `devtools`' DESCRIPTION file:

```r
Remotes:
    git::https://github.com/r-hub/rversions.git,
    git::https://github.com/r-lib/httr.git
```

In this way we install `rversions` and `httr` from GitHub.com using HTTPS protocol.
2. Remove these two packages from local lib
3. Check for dependencies

``` r
remotes::dev_package_deps("E:/Projects/Repos/devtools")
#> Needs update -----------------------------
#>  package   installed available    is_cran remote
#>  NA        NA        e55b558e6... FALSE   Git   
#>  NA        NA        21ff69f21... FALSE   Git   
#>  httr      NA        1.4.2        TRUE    CRAN  
#>  rversions NA        2.0.2        TRUE    CRAN
```

4. Install missing deps for this hacked `devtools`

``` r
remotes::install_deps('E:/Projects/Repos/devtools')
#> NA        (NA -> e55b558e6...) [Git]
#> NA        (NA -> 21ff69f21...) [Git]
#> httr      (NA -> 1.4.2.9000  ) [CRAN]
#> rversions (NA -> 2.0.2       ) [CRAN]
#> Downloading git repo https://github.com/r-hub/rversions.git
#> √  checking for file 'C:\Users\zhangxn\AppData\Local\Temp\RtmpUNqzQG\file37384de81e63/DESCRIPTION' (1.7s)
#> -  preparing 'rversions': (354ms)
#> √  checking DESCRIPTION meta-information
#> -  checking for LF line-endings in source and make files and shell scripts (426ms)
#> -  checking for empty or unneeded directories
#> -  building 'rversions_2.0.2.tar.gz'
#> 
#> Installing package into 'E:/Documents/R/win-library/4.0'
#> (as 'lib' is unspecified)
#> Downloading git repo https://github.com/r-lib/httr.git
#> √  checking for file 'C:\Users\zhangxn\AppData\Local\Temp\RtmpUNqzQG\file3738f2e5671/DESCRIPTION' (1.5s)
#> -  preparing 'httr': (1s)
#> √  checking DESCRIPTION meta-information
#> -  checking for LF line-endings in source and make files and shell scripts (1.3s)
#> -  checking for empty or unneeded directories
#> -  building 'httr_1.4.2.9000.tar.gz'
#> 
#> Installing package into 'E:/Documents/R/win-library/4.0'
#> (as 'lib' is unspecified)
#> Installing 2 packages: httr, rversions
#> Installing packages into 'E:/Documents/R/win-library/4.0'
#> (as 'lib' is unspecified)
#> package 'httr' successfully unpacked and MD5 sums checked
#> package 'rversions' successfully unpacked and MD5 sums checked
#> 
#> The downloaded binary packages are in
#>  C:\Users\zhangxn\AppData\Local\Temp\RtmpUNqzQG\downloaded_packages
#> Downloading git repo https://github.com/r-hub/rversions.git
#> √  checking for file 'C:\Users\zhangxn\AppData\Local\Temp\RtmpUNqzQG\file37383b945679/DESCRIPTION' (1.6s)
#> -  preparing 'rversions': (345ms)
#> √  checking DESCRIPTION meta-information
#> -  checking for LF line-endings in source and make files and shell scripts (478ms)
#> -  checking for empty or unneeded directories
#> -  building 'rversions_2.0.2.tar.gz'
#> 
#> Installing package into 'E:/Documents/R/win-library/4.0'
#> (as 'lib' is unspecified)
#> Downloading git repo https://github.com/r-lib/httr.git
#> √  checking for file 'C:\Users\zhangxn\AppData\Local\Temp\RtmpUNqzQG\file37385268658b/DESCRIPTION' (1.5s)
#> -  preparing 'httr': (926ms)
#> √  checking DESCRIPTION meta-information
#> -  checking for LF line-endings in source and make files and shell scripts (956ms)
#> -  checking for empty or unneeded directories
#> -  building 'httr_1.4.2.9000.tar.gz'
#> 
#> Installing package into 'E:/Documents/R/win-library/4.0'
#> (as 'lib' is unspecified)
```

5. You can see above that `remotes` installs `rversions` and `httr` three times: two from GitHub.com and one from CRAN.
6. Now check missing dependencies again:

``` r
remotes::dev_package_deps("E:/Projects/Repos/devtools")
#> Needs update -----------------------------
#>  package installed available    is_cran remote
#>  NA      NA        e55b558e6... FALSE   Git   
#>  NA      NA        21ff69f21... FALSE   Git
```

Oh no they think we still don't have `rersions` and `httr`!

7. Try to install missing deps again:

``` r
remotes::install_deps("E:/Projects/Repos/devtools")
#> NA (NA -> e55b558e6...) [Git]
#> NA (NA -> 21ff69f21...) [Git]
#> Downloading git repo https://github.com/r-hub/rversions.git
#> √  checking for file 'C:\Users\zhangxn\AppData\Local\Temp\RtmpAhwdeL\file652c3c1a2086/DESCRIPTION' (1.3s)
#> -  preparing 'rversions':
#> √  checking DESCRIPTION meta-information
#> -  checking for LF line-endings in source and make files and shell scripts (412ms)
#> -  checking for empty or unneeded directories
#> -  building 'rversions_2.0.2.tar.gz'
#> 
#> Installing package into 'E:/Documents/R/win-library/4.0'
#> (as 'lib' is unspecified)
#> Downloading git repo https://github.com/r-lib/httr.git
#> √  checking for file 'C:\Users\zhangxn\AppData\Local\Temp\RtmpAhwdeL\file652c12dde59/DESCRIPTION' (1.8s)
#> -  preparing 'httr': (882ms)
#> √  checking DESCRIPTION meta-information
#> -  checking for LF line-endings in source and make files and shell scripts (881ms)
#> -  checking for empty or unneeded directories
#> -  building 'httr_1.4.2.9000.tar.gz'
#> 
#> Installing package into 'E:/Documents/R/win-library/4.0'
#> (as 'lib' is unspecified)
#> Downloading git repo https://github.com/r-hub/rversions.git
#> √  checking for file 'C:\Users\zhangxn\AppData\Local\Temp\RtmpAhwdeL\file652c64196293/DESCRIPTION' (1.5s)
#> -  preparing 'rversions':
#> √  checking DESCRIPTION meta-information
#> -  checking for LF line-endings in source and make files and shell scripts (399ms)
#> -  checking for empty or unneeded directories
#> -  building 'rversions_2.0.2.tar.gz'
#> 
#> Installing package into 'E:/Documents/R/win-library/4.0'
#> (as 'lib' is unspecified)
#> Downloading git repo https://github.com/r-lib/httr.git
#> √  checking for file 'C:\Users\zhangxn\AppData\Local\Temp\RtmpAhwdeL\file652cb492e21/DESCRIPTION' (1.9s)
#> -  preparing 'httr': (860ms)
#> √  checking DESCRIPTION meta-information
#> -  checking for LF line-endings in source and make files and shell scripts (871ms)
#> -  checking for empty or unneeded directories
#> -  building 'httr_1.4.2.9000.tar.gz'
#> 
#> Installing package into 'E:/Documents/R/win-library/4.0'
#> (as 'lib' is unspecified)
```

Okay, this time, we install these packages, TWICE!

This error is introduced from `NA_character_` return of `remote_package_name`, then `parse_one_extra`, then `extra_deps`, then `dev_package_deps`, and finally `install_deps`.

When `remote_package_name` could give correct package name, there will be no `NA` packages in `dev_package_deps`, and `upgradable_packages` will produce correct result:

``` r
remotes::dev_package_deps("E:/Projects/Repos/devtools")
#> Needs update -----------------------------
#>  package   installed available    is_cran remote
#>  rversions NA        e55b558e6... FALSE   Git   
#>  httr      NA        21ff69f21... FALSE   Git
remotes::install_deps("E:/Projects/Repos/devtools")
#> rversions (NA -> e55b558e6...) [Git]
#> httr      (NA -> 21ff69f21...) [Git]
#> Downloading git repo https://github.com/r-hub/rversions.git
#> √  checking for file 'C:\Users\zhangxn\AppData\Local\Temp\RtmpWaJcAL\file17ac6f23707d/DESCRIPTION' (1.8s)
#> -  preparing 'rversions':
#> √  checking DESCRIPTION meta-information
#> -  checking for LF line-endings in source and make files and shell scripts (388ms)
#> -  checking for empty or unneeded directories
#> -  building 'rversions_2.0.2.tar.gz'
#> 
#> Installing package into 'E:/Documents/R/win-library/4.0'
#> (as 'lib' is unspecified)
#> Downloading git repo https://github.com/r-lib/httr.git
#> √  checking for file 'C:\Users\zhangxn\AppData\Local\Temp\RtmpWaJcAL\file17ac3ef9477c/DESCRIPTION' (1.4s)
#> -  preparing 'httr': (970ms)
#> √  checking DESCRIPTION meta-information
#> -  checking for LF line-endings in source and make files and shell scripts (1.1s)
#> -  checking for empty or unneeded directories
#> -  building 'httr_1.4.2.9000.tar.gz'
#> 
#> Installing package into 'E:/Documents/R/win-library/4.0'
#> (as 'lib' is unspecified)
#> Skipping install of 'rversions' from a git2r remote, the SHA1 (e55b558e) has not changed since last install.
#>   Use `force = TRUE` to force installation
#> Skipping install of 'httr' from a git2r remote, the SHA1 (21ff69f2) has not changed since last install.
#>   Use `force = TRUE` to force installation
remotes::dev_package_deps("E:/Projects/Repos/devtools")
```

Main fixes are in `R/install-git.R` L82-L83 and L148-L152, other diff is made by `styler`. I've also added some necessary tests and modified vignette.