### PR TITLE
Adding `git_remote` fallback for `gitlab_remote` use without full API access (Resolves #604)

### DIFF
--- a/R/install-gitlab.R
+++ b/R/install-gitlab.R
@@ -63,7 +63,7 @@ gitlab_remote <- function(repo, subdir = NULL,
   meta <- parse_git_repo(repo)
   meta$ref <- meta$ref %||% "HEAD"
 
-  if (auth_token_has_gitlab_api_access(host = host, pat = auth_token)) {
+  if (auth_token_has_gitlab_api_access(host = host, pat = auth_token) || !isTRUE(git_fallback)) {
     remote("gitlab",
       host = host,
       repo = paste(c(meta$repo, meta$subdir), collapse = "/"),
@@ -73,7 +73,7 @@ gitlab_remote <- function(repo, subdir = NULL,
       sha = sha,
       auth_token = auth_token
     )
-  } else if (isTRUE(git_fallback)) {
+  } else {
     credentials <- git_credentials()
     url <- paste0(build_url(host, repo), ".git")
 


### PR DESCRIPTION
As described in #604, the current `gitlab_remote` makes use of API endpoints that are not available to tokens generated for use within gitlab CI (stored in the [`$CI_JOB_TOKEN`](https://docs.gitlab.com/ee/api/README.html#gitlab-cicd-job-token) env var), throwing errors when these tokens are used.

This PR adds code to first ping the API at a generic endpoint (querying for [/version](https://docs.gitlab.com/ee/api/version.html)). If that request fails and `isTRUE(getOption("remotes.gitlab_git_fallback", TRUE))`, a `git_remote` is returned.

If `git2r` is available, a credentials object is created from the `auth_token`. Otherwise, the token is embedded in the url in the form of `http://gitlab-ci-token:$TOKEN@example.com/namespace/project.git`.

This allows `install_gitlab` to be used within CI jobs on non-public deployments of GitLab without the creation and embedding of personal tokens. Pipeline engineers need only to run `export GITLAB_PAT=$CI_JOB_TOKEN` prior to installing remotes.