### PR TITLE
Bioc-devel should use master branch, not 'HEAD'

### DIFF
--- a/R/install-bioc.R
+++ b/R/install-bioc.R
@@ -263,7 +263,7 @@ bioconductor_branch <- function(release, sha) {
     }
     switch(
       tolower(release),
-      devel = "HEAD",
+      devel = "master",
       paste0("RELEASE_",  gsub("\\.", "_", release))
     )
   }


### PR DESCRIPTION
When the bioc development branch is specified, remotes will use 'HEAD' as the branch. This results in something like:

```

Downloading Bioconductor repo https://git.bioconductor.org/packages/SingleR
'/usr/bin/git' clone --depth 1 --no-hardlinks --branch HEAD https://git.bioconductor.org/packages/SingleR /tmp/Rtmpnl7qak/file945***70f4705f
Cloning into '/tmp/Rtmpnl7qak/file945***70f4705f'...
warning: Could not find remote branch HEAD to clone.

```

I think the problem, unless I'm missing some git behavior, is that HEAD isnt really a branch? Per here:

https://www.bioconductor.org/developers/how-to/git/

master serves as devel, so I think we want to target that.