### PR TITLE
When requesting HEAD, dont use --branch

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # remotes (development version)
 
 * Re-license as MIT. (#551)
+* Fix bug in install_bioc() when using version='devel'. The code will now pull from the git HEAD, not a branch named 'HEAD' (@bbimber, #612).
 
 # remotes 2.3.0
 

--- a/R/install-bioc.R
+++ b/R/install-bioc.R
@@ -161,7 +161,7 @@ remote_download.bioc_xgit_remote <- function(x, quiet = FALSE) {
 
   args <- c('clone', '--depth', '1', '--no-hardlinks')
 
-  if (!is.null(x$branch)) {
+  if (!is.null(x$branch) && x&branch != 'HEAD') {
     args <- c(args, "--branch", x$branch)
   }
 

--- a/R/install-bioc.R
+++ b/R/install-bioc.R
@@ -161,7 +161,7 @@ remote_download.bioc_xgit_remote <- function(x, quiet = FALSE) {
 
   args <- c('clone', '--depth', '1', '--no-hardlinks')
 
-  if (!is.null(x$branch) && x&branch != 'HEAD') {
+  if (!is.null(x$branch) && x$branch != 'HEAD') {
     args <- c(args, "--branch", x$branch)
   }
 

--- a/R/submodule.R
+++ b/R/submodule.R
@@ -76,7 +76,7 @@ fill <- function(x) {
 
 update_submodule <- function(url, path, branch, quiet) {
   args <- c('clone', '--depth', '1', '--no-hardlinks --recurse-submodules')
-  if (length(branch) > 0 && !is.na(branch)) {
+  if (length(branch) > 0 && !is.na(branch) && branch != 'HEAD') {
     args <- c(args, "--branch", branch)
   }
   args <- c(args, url, path)

--- a/inst/install-github.R
+++ b/inst/install-github.R
@@ -2082,7 +2082,7 @@ function(...) {
   
     args <- c('clone', '--depth', '1', '--no-hardlinks')
   
-    if (!is.null(x$branch) && x&branch != 'HEAD') {
+    if (!is.null(x$branch) && x$branch != 'HEAD') {
       args <- c(args, "--branch", x$branch)
     }
   

--- a/inst/install-github.R
+++ b/inst/install-github.R
@@ -2082,7 +2082,7 @@ function(...) {
   
     args <- c('clone', '--depth', '1', '--no-hardlinks')
   
-    if (!is.null(x$branch)) {
+    if (!is.null(x$branch) && x&branch != 'HEAD') {
       args <- c(args, "--branch", x$branch)
     }
   
@@ -4898,7 +4898,7 @@ function(...) {
   
   update_submodule <- function(url, path, branch, quiet) {
     args <- c('clone', '--depth', '1', '--no-hardlinks --recurse-submodules')
-    if (length(branch) > 0 && !is.na(branch)) {
+    if (length(branch) > 0 && !is.na(branch) && branch != 'HEAD') {
       args <- c(args, "--branch", branch)
     }
     args <- c(args, url, path)

--- a/install-github.R
+++ b/install-github.R
@@ -2082,7 +2082,7 @@ function(...) {
   
     args <- c('clone', '--depth', '1', '--no-hardlinks')
   
-    if (!is.null(x$branch) && x&branch != 'HEAD') {
+    if (!is.null(x$branch) && x$branch != 'HEAD') {
       args <- c(args, "--branch", x$branch)
     }
   

--- a/install-github.R
+++ b/install-github.R
@@ -2082,7 +2082,7 @@ function(...) {
   
     args <- c('clone', '--depth', '1', '--no-hardlinks')
   
-    if (!is.null(x$branch)) {
+    if (!is.null(x$branch) && x&branch != 'HEAD') {
       args <- c(args, "--branch", x$branch)
     }
   
@@ -4898,7 +4898,7 @@ function(...) {
   
   update_submodule <- function(url, path, branch, quiet) {
     args <- c('clone', '--depth', '1', '--no-hardlinks --recurse-submodules')
-    if (length(branch) > 0 && !is.na(branch)) {
+    if (length(branch) > 0 && !is.na(branch) && branch != 'HEAD') {
       args <- c(args, "--branch", branch)
     }
     args <- c(args, url, path)


### PR DESCRIPTION
@jimhester - this is related to #580, but I missed it before.

When the bioc development branch is specified, remotes will use 'HEAD' as the branch. This results in something like:

```
Downloading Bioconductor repo https://git.bioconductor.org/packages/SingleR
'/usr/bin/git' clone --depth 1 --no-hardlinks --branch HEAD https://git.bioconductor.org/packages/SingleR /tmp/Rtmpnl7qak/file945***70f4705f
Cloning into '/tmp/Rtmpnl7qak/file945***70f4705f'...
warning: Could not find remote branch HEAD to clone.
```

I think the right solution is to not include "--branch" in the git command if the requested branch is HEAD.  I believe this has been a long-standing issue, that could not easily have been hit before.
