### PR TITLE
Adding error handling to git_remote http requests (Resolves #625)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: remotes
 Title: R Package Installation from Remote Repositories, Including 'GitHub'
-Version: 2.4.0.9000
+Version: 2.4.0.9001
 Authors@R: c(
     person("Jim", "Hester", , "jim.hester@rstudio.com", role = c("aut", "cre")),
     person("Gábor", "Csárdi", , "csardi.gabor@gmail.com", role = c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
 
 * `system_requirements()` now works as intended if only the `os` argument is used (@mdneuzerling, #609)
 
-* `remote_package_name.git2r_remote` and `remote_package_name.xgit_remote` now get correct package name from HTTP(S) git repo's `DESCRIPTION` file, and thus package's `DESCRIPTION` file's `Remotes` field could have `git::http(s)://<host>/<username>/<repo>[.git][@ref]` items that install remote packages using git via HTTP(S) protocal (@niheaven, #603).
+* `remote_package_name.git2r_remote` and `remote_package_name.xgit_remote` now get correct package name from HTTP(S) git repo's `DESCRIPTION` file (or will remain undiscovered if unauthenticated access to the HTTP(s) endpoint is unavailable), and thus package's `DESCRIPTION` file's `Remotes` field could have `git::http(s)://<host>/<username>/<repo>[.git][@ref]` items that install remote packages using git via HTTP(S) protocal (@niheaven, #603; @dgkf #628).
 
 # remotes 2.3.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
 
 * `system_requirements()` now works as intended if only the `os` argument is used (@mdneuzerling, #609)
 
-* `remote_package_name.git2r_remote` and `remote_package_name.xgit_remote` now get correct package name from HTTP(S) git repo's `DESCRIPTION` file (or will remain undiscovered if unauthenticated access to the HTTP(s) endpoint is unavailable), and thus package's `DESCRIPTION` file's `Remotes` field could have `git::http(s)://<host>/<username>/<repo>[.git][@ref]` items that install remote packages using git via HTTP(S) protocal (@niheaven, #603; @dgkf #628).
+* `remote_package_name.git2r_remote` and `remote_package_name.xgit_remote` now get correct package name from HTTP(S) git repo's `DESCRIPTION` file (or will remain undiscovered if unauthenticated access to the HTTP(s) endpoint is unavailable), and thus package's `DESCRIPTION` file's `Remotes` field could have `git::http(s)://<host>/<username>/<repo>[.git][@ref]` items that install remote packages using git via HTTP(S) protocal (@niheaven, #603; @dgkf, #628).
 
 # remotes 2.3.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # remotes (development version)
 
+* Using `remote_package_name.git2r_remote` and `remote_package_name.xgit_remote`, http responses returning an invalid `DESCRIPTION` or that redirect to another page will now fallback to return `NA` instead of throwing an error when trying to parse the unexpected content (#628, @dgkf).
+
 # remotes 2.4.0
 
 * Re-license as MIT. (#551)
@@ -8,7 +10,7 @@
 
 * `system_requirements()` now works as intended if only the `os` argument is used (@mdneuzerling, #609)
 
-* `remote_package_name.git2r_remote` and `remote_package_name.xgit_remote` now get correct package name from HTTP(S) git repo's `DESCRIPTION` file (or will remain undiscovered if unauthenticated access to the HTTP(s) endpoint is unavailable), and thus package's `DESCRIPTION` file's `Remotes` field could have `git::http(s)://<host>/<username>/<repo>[.git][@ref]` items that install remote packages using git via HTTP(S) protocal (@niheaven, #603; @dgkf, #628).
+* `remote_package_name.git2r_remote` and `remote_package_name.xgit_remote` now get correct package name from HTTP(S) git repo's `DESCRIPTION` file, and thus package's `DESCRIPTION` file's `Remotes` field could have `git::http(s)://<host>/<username>/<repo>[.git][@ref]` items that install remote packages using git via HTTP(S) protocal (@niheaven, #603).
 
 # remotes 2.3.0
 

--- a/R/install-git.R
+++ b/R/install-git.R
@@ -152,7 +152,7 @@ remote_package_name.git2r_remote <- function(remote, ...) {
       download(tmp, url)
       read_dcf(tmp)$Package
     }, error = function(e) {
-      NA_character_      
+      NA_character_
     })
   } else {
     # Try using git archive --remote to retrieve the DESCRIPTION, if the protocol

--- a/R/install-git.R
+++ b/R/install-git.R
@@ -146,9 +146,14 @@ remote_package_name.git2r_remote <- function(remote, ...) {
   description_path <- paste0(collapse = "/", c(remote$subdir, "DESCRIPTION"))
 
   if (grepl("^https?://", remote$url)) {
+    # assumes GitHub-style "<repo>/raw/<ref>/<path>" url
     url <- build_url(sub("\\.git$", "", remote$url), "raw", remote_sha(remote, ...), description_path)
-    download(tmp, url)
-    read_dcf(tmp)$Package
+    tryCatch({
+      download(tmp, url)
+      read_dcf(tmp)$Package
+    }, error = function(e) {
+      NA_character_      
+    })
   } else {
     # Try using git archive --remote to retrieve the DESCRIPTION, if the protocol
     # or server doesn't support that return NA

--- a/inst/install-github.R
+++ b/inst/install-github.R
@@ -2734,9 +2734,14 @@ function(...) {
     description_path <- paste0(collapse = "/", c(remote$subdir, "DESCRIPTION"))
   
     if (grepl("^https?://", remote$url)) {
+      # assumes GitHub-style "<repo>/raw/<ref>/<path>" url
       url <- build_url(sub("\\.git$", "", remote$url), "raw", remote_sha(remote, ...), description_path)
-      download(tmp, url)
-      read_dcf(tmp)$Package
+      tryCatch({
+        download(tmp, url)
+        read_dcf(tmp)$Package
+      }, error = function(e) {
+        NA_character_
+      })
     } else {
       # Try using git archive --remote to retrieve the DESCRIPTION, if the protocol
       # or server doesn't support that return NA

--- a/install-github.R
+++ b/install-github.R
@@ -2734,9 +2734,14 @@ function(...) {
     description_path <- paste0(collapse = "/", c(remote$subdir, "DESCRIPTION"))
   
     if (grepl("^https?://", remote$url)) {
+      # assumes GitHub-style "<repo>/raw/<ref>/<path>" url
       url <- build_url(sub("\\.git$", "", remote$url), "raw", remote_sha(remote, ...), description_path)
-      download(tmp, url)
-      read_dcf(tmp)$Package
+      tryCatch({
+        download(tmp, url)
+        read_dcf(tmp)$Package
+      }, error = function(e) {
+        NA_character_
+      })
     } else {
       # Try using git archive --remote to retrieve the DESCRIPTION, if the protocol
       # or server doesn't support that return NA

--- a/tests/testthat/test-install-git.R
+++ b/tests/testthat/test-install-git.R
@@ -165,6 +165,22 @@ test_that("remote_package_name.git2r_remote returns the package name if it exist
   url <- "https://github.com/igraph/rigraph.git@master"
   remote <- git_remote(url, git = "git2r")
   expect_equal(remote_package_name(remote), "igraph")
+
+  # works for gitlab urls
+  url <- "https://gitlab.com/r-lib-grp/test-pkg.git"
+  remote <- git_remote(url, git = "git2r")
+  expect_equal(remote_package_name(remote), "test123")
+
+  # safely returns NA when DESCRIPTION url is not accessible
+  # (condition emitted due to inaccessible git remote for remote_sha during testing)
+  url <- "https://gitlab.com/r-lib-grp/fake-private-repo.git"
+  remote <- git_remote(url, git = "git2r")
+  err <- tryCatch(remote_sha(remote), error = function(e) e)
+  expect_error(  # expect same error as calling remote_sha directly
+    expect_equal(remote_package_name(remote), NA_character_),
+    class = class(err),
+    label = conditionMessage(err)
+  )
 })
 
 test_that("remote_package_name.xgit_remote returns the package name if it exists", {


### PR DESCRIPTION
Addressing #625

- Simple error handling, returning `NA` if either the download or DESCRIPTION parsing fails. 
- Tests for a gitlab repo and an inaccessible repo (just given a fake url) to simulate an http endpoint behind authentication. (had to test to make sure the only warnings that get emitted are from `remote_sha` since it's not a real git url, but otherwise tests the http recovery). 

Happy to iterate from here, but felt it was simple enough to just get the ball rolling on it. 