### PR TITLE
Fix regex that broke `git@xxx` in `install-git`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # remotes (development version)
 
+* Fix regex that breaks git protocol in `git_remote` (@niheaven #630).
+
 # remotes 2.4.0
 
 * Re-license as MIT. (#551)

--- a/R/install-git.R
+++ b/R/install-git.R
@@ -79,7 +79,7 @@ git_remote <- function(url, subdir = NULL, ref = NULL, credentials = git_credent
     stop("`credentials` can only be used with `git = \"git2r\"`", call. = FALSE)
   }
 
-  meta <- re_match(url, "(?:(?<url>[^@]*))(?:@(?<ref>.*))?")
+  meta <- re_match(url, "(?<url>(?:git@)?[^@]*)(?:@(?<ref>.*))?")
   ref <- ref %||% (if (meta$ref == "") NULL else meta$ref)
 
   list(git2r = git_remote_git2r, external = git_remote_xgit)[[git]](meta$url, subdir, ref, credentials)

--- a/inst/install-github.R
+++ b/inst/install-github.R
@@ -2667,7 +2667,7 @@ function(...) {
       stop("`credentials` can only be used with `git = \"git2r\"`", call. = FALSE)
     }
   
-    meta <- re_match(url, "(?:(?<url>[^@]*))(?:@(?<ref>.*))?")
+    meta <- re_match(url, "(?<url>(?:git@)?[^@]*)(?:@(?<ref>.*))?")
     ref <- ref %||% (if (meta$ref == "") NULL else meta$ref)
   
     list(git2r = git_remote_git2r, external = git_remote_xgit)[[git]](meta$url, subdir, ref, credentials)

--- a/install-github.R
+++ b/install-github.R
@@ -2667,7 +2667,7 @@ function(...) {
       stop("`credentials` can only be used with `git = \"git2r\"`", call. = FALSE)
     }
   
-    meta <- re_match(url, "(?:(?<url>[^@]*))(?:@(?<ref>.*))?")
+    meta <- re_match(url, "(?<url>(?:git@)?[^@]*)(?:@(?<ref>.*))?")
     ref <- ref %||% (if (meta$ref == "") NULL else meta$ref)
   
     list(git2r = git_remote_git2r, external = git_remote_xgit)[[git]](meta$url, subdir, ref, credentials)

--- a/tests/testthat/test-install-git.R
+++ b/tests/testthat/test-install-git.R
@@ -146,7 +146,35 @@ test_that("install_git with command line git and full SHA ref", {
   expect_true(!is.na(remote$sha) && nzchar(remote$sha))
 })
 
+test_that("git_remote returns the url", {
+
+  skip_on_cran()
+
+  # works without ref
+  url <- "https://github.com/cran/falsy.git"
+  remote <- git_remote(url)
+  expect_equal(remote$url, "https://github.com/cran/falsy.git")
+
+  # works with ref
+  url <- "https://github.com/cran/falsy.git@master"
+  remote <- git_remote(url)
+  expect_equal(remote$url, "https://github.com/cran/falsy.git")
+  expect_equal(remote$ref, "master")
+
+  # works without ref (git protocol)
+  url <- "git@github.com:cran/falsy.git"
+  remote <- git_remote(url)
+  expect_equal(remote$url, "git@github.com:cran/falsy.git")
+
+  # works with ref (git protocal)
+  url <- "git@github.com:cran/falsy.git@master"
+  remote <- git_remote(url)
+  expect_equal(remote$url, "git@github.com:cran/falsy.git")
+  expect_equal(remote$ref, "master")
+})
+
 test_that("remote_package_name.git2r_remote returns the package name if it exists", {
+
   skip_on_cran()
   skip_if_offline()
   skip_if_not_installed("git2r")
@@ -168,6 +196,7 @@ test_that("remote_package_name.git2r_remote returns the package name if it exist
 })
 
 test_that("remote_package_name.xgit_remote returns the package name if it exists", {
+
   skip_on_cran()
   skip_if_offline()
   if (is.null(git_path())) skip("git is not installed")
@@ -189,6 +218,7 @@ test_that("remote_package_name.xgit_remote returns the package name if it exists
 })
 
 test_that("remote_sha.xgit remote returns the SHA if it exists", {
+
   skip_on_cran()
   skip_if_offline()
   if (is.null(git_path())) skip("git is not installed")


### PR DESCRIPTION
- Fix #621 
- Fix #627

The regex that fixed in #603 breaks `git@xxx` by accident :sob:

It just try to handle `@xxx` as `ref`, change it from `(?:(?<url>[^@]*))(?:@(?<ref>.*))?)` to `(?<url>(?:git@)?[^@]*)(?:@(?<ref>.*))?` will fix the problem.

After fix:

``` r
remotes:::git_remote("git@ssh.dev.azure.com:v3/dataapi-rclient", git = "external")
#> $url
#> [1] "git@ssh.dev.azure.com:v3/dataapi-rclient"
#> 
#> $subdir
#> NULL
#> 
#> $ref
#> NULL
#> 
#> attr(,"class")
#> [1] "xgit_remote" "remote"
remotes:::git_remote("git@gitlab.company.com:group/package.git")
#> $url
#> [1] "git@gitlab.company.com:group/package.git"
#> 
#> $subdir
#> NULL
#> 
#> $ref
#> NULL
#> 
#> $credentials
#> NULL
#> 
#> attr(,"class")
#> [1] "git2r_remote" "remote"
remotes:::git_remote("https://gitlab.company.com/group/package.git@master") 
#> $url
#> [1] "https://gitlab.company.com/group/package.git"
#> 
#> $subdir
#> NULL
#> 
#> $ref
#> [1] "master"
#> 
#> $credentials
#> NULL
#> 
#> attr(,"class")
#> [1] "git2r_remote" "remote"
remotes:::git_remote("git@gitlab.company.com:group/package.git@v3")
#> $url
#> [1] "git@gitlab.company.com:group/package.git"
#> 
#> $subdir
#> NULL
#> 
#> $ref
#> [1] "v3"
#> 
#> $credentials
#> NULL
#> 
#> attr(,"class")
#> [1] "git2r_remote" "remote"
```
