### PR TITLE
Bump bioc version map

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # remotes (development version)
 
+* `bioc_version()` now points to the most recent (2021-10-27) Bioconductor
+  release, `v3.14` (@stufield, #664).
 * Fix regex to handle user names in URL in `git_remote`, add regression tests (@achimgaedke, #646).
 
 # remotes 2.4.1

--- a/R/bioc-standalone.R
+++ b/R/bioc-standalone.R
@@ -105,7 +105,7 @@ bioconductor <- local({
     "3.5"  = package_version("3.8"),
     "3.6"  = package_version("3.10"),
     "4.0"  = package_version("3.12"),
-    "4.1"  = package_version("3.13")
+    "4.1"  = package_version("3.14")
   )
 
   # -------------------------------------------------------------------

--- a/inst/install-github.R
+++ b/inst/install-github.R
@@ -113,7 +113,7 @@ function(...) {
       "3.5"  = package_version("3.8"),
       "3.6"  = package_version("3.10"),
       "4.0"  = package_version("3.12"),
-      "4.1"  = package_version("3.13")
+      "4.1"  = package_version("3.14")
     )
   
     # -------------------------------------------------------------------

--- a/install-github.R
+++ b/install-github.R
@@ -113,7 +113,7 @@ function(...) {
       "3.5"  = package_version("3.8"),
       "3.6"  = package_version("3.10"),
       "4.0"  = package_version("3.12"),
-      "4.1"  = package_version("3.13")
+      "4.1"  = package_version("3.14")
     )
   
     # -------------------------------------------------------------------

--- a/man/github_remote.Rd
+++ b/man/github_remote.Rd
@@ -30,7 +30,8 @@ for more details.}
 \item{subdir}{Subdirectory within repo that contains the R package.}
 
 \item{auth_token}{To install from a private repo, generate a personal
-access token (PAT) in "https://github.com/settings/tokens" and
+access token (PAT) with at least repo scope in
+\url{https://github.com/settings/tokens} and
 supply to this argument. This is safer than using a password because
 you can easily delete a PAT without affecting any others. Defaults to
 the \code{GITHUB_PAT} environment variable.}

--- a/man/install_github.Rd
+++ b/man/install_github.Rd
@@ -39,7 +39,8 @@ for more details.}
 \item{subdir}{Subdirectory within repo that contains the R package.}
 
 \item{auth_token}{To install from a private repo, generate a personal
-access token (PAT) in "https://github.com/settings/tokens" and
+access token (PAT) with at least repo scope in
+\url{https://github.com/settings/tokens} and
 supply to this argument. This is safer than using a password because
 you can easily delete a PAT without affecting any others. Defaults to
 the \code{GITHUB_PAT} environment variable.}

--- a/man/install_gitlab.Rd
+++ b/man/install_gitlab.Rd
@@ -29,7 +29,8 @@ install_gitlab(
 \item{subdir}{Subdirectory within repo that contains the R package.}
 
 \item{auth_token}{To install from a private repo, generate a personal access
-token (PAT) in \url{https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html} and
+token (PAT) with at least read_api scope in
+\url{https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html} and
 supply to this argument. This is safer than using a password because you
 can easily delete a PAT without affecting any others. Defaults to the
 GITLAB_PAT environment variable.}

--- a/man/system_requirements.Rd
+++ b/man/system_requirements.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/system_requirements.R
 \name{system_requirements}
 \alias{system_requirements}
-\title{Query the system requirements for a dev package (and its dependencies)}
+\title{Query the system requirements for a package (and its dependencies)}
 \usage{
 system_requirements(
   os,
@@ -22,7 +22,8 @@ and the version separated by a dash, e.g. \code{"ubuntu-18.04"}.}
 
 \item{path}{The path to the dev package's root directory.}
 
-\item{package}{A CRAN package name. If not \code{NULL}, this is used and \code{path} is ignored.}
+\item{package}{CRAN package name(s) to lookup system requirements for. If not
+\code{NULL}, this is used and \code{path} is ignored.}
 
 \item{curl}{The location of the curl binary on your system.}
 }

--- a/tests/testthat/test-bioc.R
+++ b/tests/testthat/test-bioc.R
@@ -39,7 +39,7 @@ test_that("internal map is current", {
   skip_if_offline()
   expect_equal(
     bioconductor$get_release_version(),
-    package_version("3.13"))
+    package_version("3.14"))
 })
 
 test_that("set of repos are correct", {


### PR DESCRIPTION
- bumped BioC version map for R 4.1 from 3.13 -> 3.14
- re-sync *.Rd files (4 files out of date compared to *.R roxygen) (2nd commit)