### PR TITLE
Unadvertised SHAs don't work for github/bitbucket

### DIFF
--- a/R/install-git.R
+++ b/R/install-git.R
@@ -264,7 +264,7 @@ remote_download.xgit_remote <- function(x, quiet = FALSE) {
 
   bundle <- tempfile()
 
-  disallows_unadvertised <- grepl("github|bitbucket", tolower(x$url))
+  disallows_unadvertised <- grepl("(github|bitbucket)[.]com", tolower(x$url))
   args <- c("clone", if (is.null(x$ref) && disallows_unadvertised) c("--depth", "1"), "--no-hardlinks")
   args <- c(args, x$args, x$url, bundle)
   git(paste0(args, collapse = " "), quiet = quiet)

--- a/R/install-git.R
+++ b/R/install-git.R
@@ -264,13 +264,18 @@ remote_download.xgit_remote <- function(x, quiet = FALSE) {
 
   bundle <- tempfile()
 
-  args <- c("clone", if (is.null(x$ref)) c("--depth", "1"), "--no-hardlinks")
+  disallows_unadvertised <- grepl("github|bitbucket", tolower(x$url))
+  args <- c("clone", if (is.null(x$ref) && disallows_unadvertised) c("--depth", "1"), "--no-hardlinks")
   args <- c(args, x$args, x$url, bundle)
   git(paste0(args, collapse = " "), quiet = quiet)
 
   if (!is.null(x$ref)) {
-    git(paste0(c("fetch", "origin", x$ref), collapse = " "), quiet = quiet, path = bundle)
-    git(paste0(c("checkout", "FETCH_HEAD"), collapse = " "), quiet = quiet, path = bundle)
+    if (!disallows_unadvertised) {
+      git(paste0(c("fetch", "origin", x$ref), collapse = " "), quiet = quiet, path = bundle)
+      git(paste0(c("checkout", "FETCH_HEAD"), collapse = " "), quiet = quiet, path = bundle)
+    } else {
+      git(paste0(c("checkout", x$ref), collapse = " "), quiet = quiet, path = bundle)
+    }
   }
 
   bundle

--- a/R/install-git.R
+++ b/R/install-git.R
@@ -264,7 +264,7 @@ remote_download.xgit_remote <- function(x, quiet = FALSE) {
 
   bundle <- tempfile()
 
-  args <- c("clone", "--depth", "1", "--no-hardlinks")
+  args <- c("clone", if (is.null(x$ref)) c("--depth", "1"), "--no-hardlinks")
   args <- c(args, x$args, x$url, bundle)
   git(paste0(args, collapse = " "), quiet = quiet)
 


### PR DESCRIPTION
Fixes #674.  I know it's heavy handed in the sense that github/bitbucket git repos are going full depth, but otherwise you can't use SSH with `install_git` to specific SHAs.  

The use case is using SSH keys (as opposed to GITHUB_PAT for a number of reasons) and you want to install specific references of packages for a reproducible environment.  `git fetch origin SHA` won't work for these.