### PR TITLE
allowing git to passthrough for a git external remote as compared to …

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,7 +42,7 @@ Suggests:
 Depends:
     R (>= 3.0.0)
 VignetteBuilder: knitr
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 SystemRequirements: Subversion for install_svn, git for install_git
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)

--- a/R/install-git.R
+++ b/R/install-git.R
@@ -47,23 +47,24 @@ install_git <- function(url, subdir = NULL, ref = NULL, branch = NULL,
   }
 
   remotes <- lapply(url, git_remote,
-    subdir = subdir, ref = ref,
-    credentials = credentials, git = match.arg(git)
+                    subdir = subdir, ref = ref,
+                    credentials = credentials, git = match.arg(git)
   )
 
   install_remotes(remotes,
-    credentials = credentials,
-    dependencies = dependencies,
-    upgrade = upgrade,
-    force = force,
-    quiet = quiet,
-    build = build,
-    build_opts = build_opts,
-    build_manual = build_manual,
-    build_vignettes = build_vignettes,
-    repos = repos,
-    type = type,
-    ...
+                  credentials = credentials,
+                  dependencies = dependencies,
+                  upgrade = upgrade,
+                  force = force,
+                  quiet = quiet,
+                  build = build,
+                  build_opts = build_opts,
+                  build_manual = build_manual,
+                  build_vignettes = build_vignettes,
+                  repos = repos,
+                  type = type,
+                  git = match.arg(git),
+                  ...
   )
 }
 
@@ -79,8 +80,8 @@ git_remote <- function(url, subdir = NULL, ref = NULL, credentials = git_credent
     stop("`credentials` can only be used with `git = \"git2r\"`", call. = FALSE)
   }
 
-   url_parts = re_match( url,
-         "(?<protocol>[^/]*://)?(?<authhost>[^/]+)(?<path>[^@]*)(@(?<ref>.*))?")
+  url_parts = re_match( url,
+                        "(?<protocol>[^/]*://)?(?<authhost>[^/]+)(?<path>[^@]*)(@(?<ref>.*))?")
 
   ref <- ref %||% (if (url_parts$ref == "") NULL else url_parts$ref)
 
@@ -92,19 +93,19 @@ git_remote <- function(url, subdir = NULL, ref = NULL, credentials = git_credent
 
 git_remote_git2r <- function(url, subdir = NULL, ref = NULL, credentials = git_credentials()) {
   remote("git2r",
-    url = url,
-    subdir = subdir,
-    ref = ref,
-    credentials = credentials
+         url = url,
+         subdir = subdir,
+         ref = ref,
+         credentials = credentials
   )
 }
 
 
 git_remote_xgit <- function(url, subdir = NULL, ref = NULL, credentials = git_credentials()) {
   remote("xgit",
-    url = url,
-    subdir = subdir,
-    ref = ref
+         url = url,
+         subdir = subdir,
+         ref = ref
   )
 }
 
@@ -169,7 +170,7 @@ remote_package_name.git2r_remote <- function(remote, ...) {
         download_args$basic_auth <- list(
           user = Sys.getenv(remote$credentials$username),
           password = Sys.getenv(remote$credentials$username)
-       )
+        )
       } else if (inherits(remote$credentials, "cred_token")) {
         if (Sys.getenv(remote$credentials$token) == "") {
           stop(paste0("Environment variable `", remote$credentials$token, "` is unset."), .call = FALSE)
@@ -199,21 +200,36 @@ remote_package_name.git2r_remote <- function(remote, ...) {
     res <- try(
       silent = TRUE,
       system_check(git_path(),
-        args = c(
-          "archive", "-o", tmp, "--remote", remote$url,
-          if (is.null(remote$ref)) "HEAD" else remote$ref,
-          description_path
-        ),
-        quiet = TRUE
+                   args = c(
+                     "archive", "-o", tmp, "--remote", remote$url,
+                     if (is.null(remote$ref)) "HEAD" else remote$ref,
+                     description_path
+                   ),
+                   quiet = TRUE
       )
     )
 
     if (inherits(res, "try-error")) {
-      return(NA_character_)
+      res <- try(
+        silent = TRUE,
+        {
+          bundle <- remote_download(remote, quiet = TRUE)
+          bundle_description_path <- file.path(bundle, description_path)
+          if (file.exists(bundle_description_path)) {
+            description_path_dir <- file.path(tempdir(), dirname(description_path))
+            dir.create(description_path_dir, recursive = TRUE,
+                       showWarnings = FALSE)
+            file.copy(bundle_description_path,
+                      file.path(tempdir(), description_path))
+          }
+        })
+      if (inherits(res, "try-error")) {
+        return(NA_character_)
+      }
+    } else {
+      # git archive returns a tar file, so extract it to tempdir and read the DCF
+      utils::untar(tmp, files = description_path, exdir = tempdir())
     }
-
-    # git archive returns a tar file, so extract it to tempdir and read the DCF
-    utils::untar(tmp, files = description_path, exdir = tempdir())
 
     read_dcf(file.path(tempdir(), description_path))$Package
   }

--- a/R/install.R
+++ b/R/install.R
@@ -175,6 +175,9 @@ r_error_matches <- function(msg, str) {
 #' @param build_opts Options to pass to `R CMD build`, only used when `build` is `TRUE`.
 #' @param build_manual If `FALSE`, don't build PDF manual ('--no-manual').
 #' @param build_vignettes If `FALSE`, don't build package vignettes ('--no-build-vignettes').
+#' @param git Whether to use the `git2r` package, or an external
+#'   git client via system. Default is `git2r` if it is installed,
+#'   otherwise an external git installation.
 #' @export
 #' @examples
 #' \dontrun{install_deps(".")}
@@ -187,12 +190,14 @@ install_deps <- function(pkgdir = ".", dependencies = NA,
                          build = TRUE,
                          build_opts = c("--no-resave-data", "--no-manual", "--no-build-vignettes"),
                          build_manual = FALSE, build_vignettes = FALSE,
+                         git = c("auto", "git2r", "external"),
                          ...) {
   packages <- dev_package_deps(
     pkgdir,
     repos = repos,
     dependencies = dependencies,
-    type = type
+    type = type,
+    git = git
   )
 
   dep_deps <- if (isTRUE(dependencies)) NA else dependencies

--- a/man/github_remote.Rd
+++ b/man/github_remote.Rd
@@ -30,7 +30,8 @@ for more details.}
 \item{subdir}{Subdirectory within repo that contains the R package.}
 
 \item{auth_token}{To install from a private repo, generate a personal
-access token (PAT) in "https://github.com/settings/tokens" and
+access token (PAT) with at least repo scope in
+\url{https://github.com/settings/tokens} and
 supply to this argument. This is safer than using a password because
 you can easily delete a PAT without affecting any others. Defaults to
 the \code{GITHUB_PAT} environment variable.}

--- a/man/install_deps.Rd
+++ b/man/install_deps.Rd
@@ -15,6 +15,7 @@ install_deps(
   build_opts = c("--no-resave-data", "--no-manual", "--no-build-vignettes"),
   build_manual = FALSE,
   build_vignettes = FALSE,
+  git = c("auto", "git2r", "external"),
   ...
 )
 }
@@ -59,6 +60,10 @@ to "always". \code{TRUE} and \code{FALSE} are also accepted and correspond to
 \item{build_manual}{If \code{FALSE}, don't build PDF manual ('--no-manual').}
 
 \item{build_vignettes}{If \code{FALSE}, don't build package vignettes ('--no-build-vignettes').}
+
+\item{git}{Whether to use the \code{git2r} package, or an external
+git client via system. Default is \code{git2r} if it is installed,
+otherwise an external git installation.}
 
 \item{...}{additional arguments passed to \code{\link[utils:install.packages]{utils::install.packages()}}.}
 }

--- a/man/install_github.Rd
+++ b/man/install_github.Rd
@@ -39,7 +39,8 @@ for more details.}
 \item{subdir}{Subdirectory within repo that contains the R package.}
 
 \item{auth_token}{To install from a private repo, generate a personal
-access token (PAT) in "https://github.com/settings/tokens" and
+access token (PAT) with at least repo scope in
+\url{https://github.com/settings/tokens} and
 supply to this argument. This is safer than using a password because
 you can easily delete a PAT without affecting any others. Defaults to
 the \code{GITHUB_PAT} environment variable.}

--- a/man/install_gitlab.Rd
+++ b/man/install_gitlab.Rd
@@ -29,7 +29,8 @@ install_gitlab(
 \item{subdir}{Subdirectory within repo that contains the R package.}
 
 \item{auth_token}{To install from a private repo, generate a personal access
-token (PAT) in \url{https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html} and
+token (PAT) with at least read_api scope in
+\url{https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html} and
 supply to this argument. This is safer than using a password because you
 can easily delete a PAT without affecting any others. Defaults to the
 GITLAB_PAT environment variable.}

--- a/man/package_deps.Rd
+++ b/man/package_deps.Rd
@@ -20,7 +20,8 @@ dev_package_deps(
   pkgdir = ".",
   dependencies = NA,
   repos = getOption("repos"),
-  type = getOption("pkgType")
+  type = getOption("pkgType"),
+  git = c("auto", "git2r", "external")
 )
 
 \method{update}{package_deps}(
@@ -64,6 +65,10 @@ common ones include:
 \item{type}{Type of package to \code{update}.}
 
 \item{pkgdir}{Path to a package directory, or to a package tarball.}
+
+\item{git}{Whether to use the \code{git2r} package, or an external
+git client via system. Default is \code{git2r} if it is installed,
+otherwise an external git installation.}
 
 \item{object}{A \code{package_deps} object.}
 

--- a/tests/testthat/test-deps.R
+++ b/tests/testthat/test-deps.R
@@ -359,6 +359,19 @@ test_that("remotes are parsed with explicit host", {
 
 })
 
+test_that("git remotes for git2r and xgit", {
+
+  expect_equal(
+    parse_one_extra("git::git@github.com:hadley/testthat", git = "external"),
+    git_remote("git@github.com:hadley/testthat", git = "external"))
+
+
+  expect_equal(
+    parse_one_extra("git::git@github.com:hadley/testthat", git = "git2r"),
+    git_remote("git@github.com:hadley/testthat", git = "git2r"))
+
+})
+
 test_that("type = 'both' works well", {
 
   skip_on_cran()


### PR DESCRIPTION
This passes the `git` argument all the way through on the `install_remotes` so that if you have any remote dependencies with a prefix of `git::` and you set `git = "external"` on an `install*` (my use case of using SSH keys and no GITHUB_PAT).

Here's a reprex that shows the use case.  I can turn into an issue if that is better for tracking.  I can't show an example of the failure of 

``` r
library(remotes)
library(desc)
tfile = tempfile()
dir.create(tfile)
desc_file = file.path(tfile, "DESCRIPTION")
desc = desc::description$new("!new")
desc$set("Package", "temporary")
desc$del("Maintainer")
desc$set_dep(package = "stringr", type = "Imports", version = ">= 1.0.0")
desc$add_remotes("git::git@github.com:hadley/stringr")
desc$write(desc_file)

x = sessioninfo::session_info("stringr")$package
#> Warning in system("timedatectl", intern = TRUE): running command 'timedatectl'
#> had status 1
src = x$source[x$package == "stringr"]
src = sub(".*\\((.*)\\)", "\\1", src)
remove.packages("stringr")
#> Removing package from '/home/jupyter/.R/library'
#> (as 'lib' is unspecified)
remotes::install_local(path = tfile, git = "external")
#> stringr (NA -> 5f48256b5...) [Git]
#> Downloading git repo git@github.com:hadley/stringr
#> '/usr/bin/git' clone --depth 1 --no-hardlinks git@github.com:hadley/stringr /tmp/RtmpkfNJg9/file3f4d5354a09
#> 
#> * checking for file ‘/tmp/RtmpkfNJg9/file3f4d5354a09/DESCRIPTION’ ... OK
#> * preparing ‘stringr’:
#> * checking DESCRIPTION meta-information ... OK
#> * checking for LF line-endings in source and make files and shell scripts
#> * checking for empty or unneeded directories
#> * building ‘stringr_1.4.0.9000.tar.gz’
#> Installing package into '/home/jupyter/.R/library'
#> (as 'lib' is unspecified)
#> Skipping install of 'stringr' from a xgit remote, the SHA1 (5f48256b) has not changed since last install.
#>   Use `force = TRUE` to force installation
#> * checking for file ‘/tmp/RtmpkfNJg9/file3f4d70f9acd3/file3f4d650bbaaa/DESCRIPTION’ ... OK
#> * preparing ‘temporary’:
#> * checking DESCRIPTION meta-information ... OK
#> * checking for LF line-endings in source and make files and shell scripts
#> * checking for empty or unneeded directories
#> * creating default NAMESPACE file
#> * building ‘temporary_1.0.0.tar.gz’
#> Installing package into '/home/jupyter/.R/library'
#> (as 'lib' is unspecified)
remove.packages("temporary")
#> Removing package from '/home/jupyter/.R/library'
#> (as 'lib' is unspecified)
remotes::install_local(path = tfile)
#> Error: Failed to install 'temporary' from local:
#>   Error in 'git2r_remote_ls': error authenticating:
remove.packages("temporary")
#> Removing package from '/home/jupyter/.R/library'
#> (as 'lib' is unspecified)
#> Error in find.package(pkgs, lib): there is no package called 'temporary'
remotes::install_git(src, upgrade = FALSE, git = "external")
#> Downloading git repo git@github.com:tidyverse/stringr.git
#> '/usr/bin/git' clone --depth 1 --no-hardlinks git@github.com:tidyverse/stringr.git /tmp/RtmpkfNJg9/file3f4d64e1397c
#> '/usr/bin/git' fetch origin dd909b714b20ff3add2eedb0a1c917ba6938e40e
#> '/usr/bin/git' checkout FETCH_HEAD
#> * checking for file ‘/tmp/RtmpkfNJg9/file3f4d64e1397c/DESCRIPTION’ ... OK
#> * preparing ‘stringr’:
#> * checking DESCRIPTION meta-information ... OK
#> * checking for LF line-endings in source and make files and shell scripts
#> * checking for empty or unneeded directories
#> * building ‘stringr_1.4.0.9000.tar.gz’
#> Installing package into '/home/jupyter/.R/library'
#> (as 'lib' is unspecified)

res = dev_package_deps(pkgdir = tfile)
#> Error in git2r::remote_ls(remote$url, credentials = remote$credentials): Error in 'git2r_remote_ls': error authenticating:
res
#> Error in eval(expr, envir, enclos): object 'res' not found
res = dev_package_deps(pkgdir = tfile, git = "external")
res
#> Needs update -----------------------------
#>  package installed    available    is_cran remote
#>  stringr dd909b714... 5f48256b5... FALSE   Git
```

<sup>Created on 2021-12-14 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

<details style="margin-bottom:10px;">
<summary>
Session info
</summary>

``` r
sessioninfo::session_info()
#> ─ Session info ───────────────────────────────────────────────────────────────
#>  setting  value
#>  version  R version 4.1.2 (2021-11-01)
#>  os       Debian GNU/Linux 10 (buster)
#>  system   x86_64, linux-gnu
#>  ui       X11
#>  language (EN)
#>  collate  C.UTF-8
#>  ctype    C.UTF-8
#>  tz       Etc/UTC
#>  date     2021-12-14
#>  pandoc   2.14.0.2 @ /opt/conda/bin/ (via rmarkdown)
#> 
#> ─ Packages ───────────────────────────────────────────────────────────────────
#>  package     * version    date (UTC) lib source
#>  callr         3.7.0      2021-04-20 [2] CRAN (R 4.1.0)
#>  cli           3.1.0.9000 2021-12-07 [1] Github (r-lib/cli@aaf7cf1)
#>  crayon        1.4.2      2021-10-29 [1] CRAN (R 4.1.0)
#>  curl          4.3.2      2021-06-23 [1] CRAN (R 4.1.0)
#>  desc        * 1.4.0      2021-09-28 [1] CRAN (R 4.1.0)
#>  digest        0.6.29     2021-12-01 [1] CRAN (R 4.1.2)
#>  evaluate      0.14       2019-05-28 [2] CRAN (R 4.1.0)
#>  fastmap       1.1.0      2021-01-25 [2] CRAN (R 4.1.0)
#>  fs            1.5.2      2021-12-08 [1] CRAN (R 4.1.2)
#>  git2r         0.29.0     2021-11-22 [1] CRAN (R 4.1.0)
#>  glue          1.5.1      2021-11-30 [1] CRAN (R 4.1.0)
#>  highr         0.9        2021-04-16 [2] CRAN (R 4.1.0)
#>  htmltools     0.5.2      2021-08-25 [1] CRAN (R 4.1.0)
#>  knitr         1.36       2021-09-29 [1] CRAN (R 4.1.0)
#>  lifecycle     1.0.1      2021-09-24 [1] CRAN (R 4.1.0)
#>  magrittr      2.0.1      2020-11-17 [2] CRAN (R 4.1.0)
#>  pkgbuild      1.3.0      2021-12-09 [1] CRAN (R 4.1.2)
#>  prettyunits   1.1.1      2020-01-24 [2] CRAN (R 4.1.0)
#>  processx      3.5.2      2021-04-30 [2] CRAN (R 4.1.0)
#>  ps            1.6.0      2021-02-28 [2] CRAN (R 4.1.0)
#>  R6            2.5.1      2021-08-19 [1] CRAN (R 4.1.0)
#>  remotes     * 2.4.1.9000 2021-12-14 [1] local
#>  reprex        2.0.1      2021-08-05 [1] CRAN (R 4.1.0)
#>  rlang         0.4.12     2021-10-18 [1] CRAN (R 4.1.0)
#>  rmarkdown     2.11       2021-09-14 [1] CRAN (R 4.1.0)
#>  rprojroot     2.0.2      2020-11-15 [2] CRAN (R 4.1.0)
#>  rstudioapi    0.13       2020-11-12 [2] CRAN (R 4.1.0)
#>  sessioninfo   1.2.2      2021-12-06 [1] CRAN (R 4.1.2)
#>  stringi       1.7.6      2021-11-29 [1] CRAN (R 4.1.0)
#>  stringr       1.4.0.9000 2021-12-14 [1] xgit (git@github.com:tidyverse/stringr.git@dd909b7)
#>  vctrs         0.3.8      2021-04-29 [2] CRAN (R 4.1.0)
#>  withr         2.4.3      2021-11-30 [1] CRAN (R 4.1.0)
#>  xfun          0.28       2021-11-04 [1] CRAN (R 4.1.0)
#>  yaml          2.2.1      2020-02-01 [2] CRAN (R 4.1.0)
#> 
#>  [1] /home/jupyter/.R/library
#>  [2] /usr/local/lib/R/site-library
#>  [3] /usr/lib/R/site-library
#>  [4] /usr/lib/R/library
#> 
#> ──────────────────────────────────────────────────────────────────────────────
```

</details>

