### PR TITLE
Allow explicit package names in Remotes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 
 * `install_github()` now uses credentials from the git credential store,
   if `GITHUB_PAT` and `GITHUB_TOKEN` are not set.
+* Remotes field accepts explicit package names: `<pkgname>=<type>::<username>/<repo>` (#719, @heavywatal).
 
 # remotes 2.4.2
 

--- a/R/deps.R
+++ b/R/deps.R
@@ -533,12 +533,7 @@ parse_one_extra <- function(x, ...) {
     stop("Malformed remote specification '", x, "'", call. = FALSE)
   }
 
-  if (grepl("=", type, fixed = TRUE)) {
-    # Allow different names for package and repo
-    tah <- strsplit(type, "=", fixed = TRUE)[[1]]
-    pkgname <- tah[1]
-    type <- tah[2]
-  }
+  type = sub("^[.a-zA-Z0-9]+=", "", type)
 
   if (grepl("@", type)) {
     # Custom host

--- a/R/deps.R
+++ b/R/deps.R
@@ -533,6 +533,13 @@ parse_one_extra <- function(x, ...) {
     stop("Malformed remote specification '", x, "'", call. = FALSE)
   }
 
+  if (grepl("=", type, fixed = TRUE)) {
+    # Allow different names for package and repo
+    tah <- strsplit(type, "=", fixed = TRUE)[[1]]
+    pkgname <- tah[1]
+    type <- tah[2]
+  }
+
   if (grepl("@", type)) {
     # Custom host
     tah <- strsplit(type, "@", fixed = TRUE)[[1]]

--- a/inst/install-github.R
+++ b/inst/install-github.R
@@ -1070,12 +1070,7 @@ function(...) {
       stop("Malformed remote specification '", x, "'", call. = FALSE)
     }
   
-    if (grepl("=", type, fixed = TRUE)) {
-      # Allow different names for package and repo
-      tah <- strsplit(type, "=", fixed = TRUE)[[1]]
-      pkgname <- tah[1]
-      type <- tah[2]
-    }
+    type = sub("^[.a-zA-Z0-9]+=", "", type)
   
     if (grepl("@", type)) {
       # Custom host

--- a/inst/install-github.R
+++ b/inst/install-github.R
@@ -1070,6 +1070,13 @@ function(...) {
       stop("Malformed remote specification '", x, "'", call. = FALSE)
     }
   
+    if (grepl("=", type, fixed = TRUE)) {
+      # Allow different names for package and repo
+      tah <- strsplit(type, "=", fixed = TRUE)[[1]]
+      pkgname <- tah[1]
+      type <- tah[2]
+    }
+  
     if (grepl("@", type)) {
       # Custom host
       tah <- strsplit(type, "@", fixed = TRUE)[[1]]

--- a/install-github.R
+++ b/install-github.R
@@ -1070,12 +1070,7 @@ function(...) {
       stop("Malformed remote specification '", x, "'", call. = FALSE)
     }
   
-    if (grepl("=", type, fixed = TRUE)) {
-      # Allow different names for package and repo
-      tah <- strsplit(type, "=", fixed = TRUE)[[1]]
-      pkgname <- tah[1]
-      type <- tah[2]
-    }
+    type = sub("^[.a-zA-Z0-9]+=", "", type)
   
     if (grepl("@", type)) {
       # Custom host

--- a/install-github.R
+++ b/install-github.R
@@ -1070,6 +1070,13 @@ function(...) {
       stop("Malformed remote specification '", x, "'", call. = FALSE)
     }
   
+    if (grepl("=", type, fixed = TRUE)) {
+      # Allow different names for package and repo
+      tah <- strsplit(type, "=", fixed = TRUE)[[1]]
+      pkgname <- tah[1]
+      type <- tah[2]
+    }
+  
     if (grepl("@", type)) {
       # Custom host
       tah <- strsplit(type, "@", fixed = TRUE)[[1]]

--- a/tests/testthat/test-deps.R
+++ b/tests/testthat/test-deps.R
@@ -359,6 +359,12 @@ test_that("remotes are parsed with explicit host", {
 
 })
 
+test_that("remotes are parsed with explicit package names", {
+  expect_equal(
+    parse_one_extra("testthat=github::hadley/testthat"),
+    github_remote("hadley/testthat"))
+})
+
 test_that("type = 'both' works well", {
 
   skip_on_cran()


### PR DESCRIPTION
This package somehow manages differences in repo names vs package names. Ignoring the leading "pkgname=" part is enough to let this package work.

Addresses #676