### PR TITLE
Update pkgdown

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -21,3 +21,4 @@
 ^\.github$
 ^LICENSE\.md$
 ^MAINTENANCE\.md$
+^pkgdown$

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ doc
 /.env
 docs/
 /inst/doc
+docs

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Authors@R: c(
     person("Jim", "Hester", , "jim.hester@rstudio.com", role = "aut"),
     person("Hadley", "Wickham", role = c("aut")),
     person("Winston", "Chang", role = "aut"),
-    person("RStudio", role = "cph"),
+    person("RStudio", role = c("cph", "fnd")),
     person("Martin", "Morgan", role = "aut"),
     person("Dan", "Tenenbaum", role = "aut"),
     person("Mango Solutions", role = "cph")
@@ -16,7 +16,8 @@ Description: Download and install R packages stored in 'GitHub', 'GitLab',
     This package provides the 'install_*' functions in 'devtools'. Indeed most 
     of the code was copied over from 'devtools'.
 License: MIT + file LICENSE
-URL: https://remotes.r-lib.org, https://github.com/r-lib/remotes#readme
+URL: https://remotes.r-lib.org,
+    https://github.com/r-lib/remotes#readme
 BugReports: https://github.com/r-lib/remotes/issues
 Imports:
     methods,
@@ -46,3 +47,4 @@ RoxygenNote: 7.2.1
 SystemRequirements: Subversion for install_svn, git for install_git
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
+Config/Needs/website: tidyverse/tidytemplate

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,5 +1,8 @@
 url: https://remotes.r-lib.org
 
+development:
+  mode: auto
+
 template:
   package: tidytemplate
   bootstrap: 5

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,13 @@
 url: https://remotes.r-lib.org
+
+template:
+  package: tidytemplate
+  bootstrap: 5
+
+  includes:
+    in_header: |
+      <script defer data-domain="remotes.r-lib.org,all.tidyverse.org" src="https://plausible.io/js/plausible.js"></script>
+
 reference:
   - title: Package Installation
     desc: Tools for installing packages from a variety of locations.


### PR DESCRIPTION
Following the checklist at [tidytemplate](https://github.com/tidyverse/tidytemplate#updating)

* [x] `usethis::use_pkgdown_github_pages()`
* [x] Ensure Author includes RStudio as copyright holder and funder
* [x] Update `DESCRIPTION` to include `Config/Needs/website: tidyverse/tidytemplate`
* [x] Update `_pkgdown.yml` with appropriate template above.
* [ ] ~Ping Hadley to add plausible.io record~
* [ ] ~Remove `strip_header: true`~
* [ ] ~Remove algolia search, if used~
* [ ] ~Eliminate superseded navbar customisation (`home: ~`, article re-ordering)~
* [ ] ~Update `news` structure if needed~
* [ ] ~Remove any author info for tidyverse folks (since now included in template)~