### PR TITLE
Optionally skip tests requiring 'codetools'

### DIFF
--- a/tests/testthat/test-bioc.R
+++ b/tests/testthat/test-bioc.R
@@ -10,6 +10,7 @@ test_that("bioc is standalone", {
   funs <- Filter(function(x) is.function(stenv[[x]]), objs)
   funobjs <- mget(funs, stenv)
 
+  skip_if_not_installed("codetools")
   expect_message(
     mapply(codetools::checkUsage, funobjs, funs,
            MoreArgs = list(report = message)),


### PR DESCRIPTION
Recommended packages not available for all installations