### PR TITLE
local_package_deps: turn warning into error 

### DIFF
--- a/R/package.R
+++ b/R/package.R
@@ -1,7 +1,7 @@
 
 load_pkg_description <- function(path) {
 
-  path <- normalizePath(path)
+  path <- normalizePath(path, mustWork = TRUE)
 
   if (!is_dir(path)) {
     dir <- tempfile()


### PR DESCRIPTION
local_package_deps("wrongpath") will now fail for wrong/inexisting directory, instead of throwing warnign then unrealted error, see #756 